### PR TITLE
Support big endian TIFF files

### DIFF
--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass, replace
-from enum import Enum
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from zarr.abc.codec import ArrayBytesCodec, ArrayArrayCodec
+from zarr.codecs.bytes import Endian
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
 from zarr.core.common import JSON, parse_enum, parse_named_configuration
 from zarr.registry import register_codec
@@ -20,28 +19,14 @@ if TYPE_CHECKING:
     from zarr.core.array_spec import ArraySpec
 
 
-class Endian(Enum):
-    """
-    Enum for endian type used by bytes codec.
-    """
-
-    big = "big"
-    little = "little"
-
-
-default_system_endian = Endian(sys.byteorder)
-
-
 @dataclass(frozen=True)
 class ChunkyCodec(ArrayBytesCodec):
     is_fixed_size = True
 
     endian: Endian | None
 
-    def __init__(self) -> None:
-        endian = default_system_endian
+    def __init__(self, *, endian: Endian | str | None = "little") -> None:
         endian_parsed = None if endian is None else parse_enum(endian, Endian)
-
         object.__setattr__(self, "endian", endian_parsed)
 
     @classmethod

--- a/src/virtual_tiff/constants.py
+++ b/src/virtual_tiff/constants.py
@@ -15,6 +15,7 @@ from virtual_tiff.imagecodecs import (
 )
 from numcodecs.zarr3 import Zlib, LZMA
 
+ENDIAN = {b"MM": "big", b"II": "little"}
 COMPRESSORS = {
     1: None,
     8: Zlib,

--- a/tests/test_gdal_examples.py
+++ b/tests/test_gdal_examples.py
@@ -43,12 +43,6 @@ def run_gdal_test(filename, filepath):
             NotImplementedError,
             "YCbCr PhotometricInterpretation is not yet supported.",
         )
-    elif filename in big_endian:
-        match_error(
-            filepath,
-            NotImplementedError,
-            "Big endian TIFFs are not yet supported.",
-        )
     elif filename in partial_chunks:
         match_error(
             filepath,
@@ -122,10 +116,10 @@ unknown_compressor = [
 ]
 YCbCr = [
     "rgbsmall_JPEG_ycbcr.tif",
-    # "zackthecat_corrupted.tif",
+    "zackthecat_corrupted.tif",
     # "tif_jpeg_ycbcr_too_big_last_stripe.tif",
     "sasha.tif",
-    # "zackthecat.tif",
+    "zackthecat.tif",
     "ycbcr_with_mask.tif",
     "mandrilmini_12bitjpeg.tif",
     "ycbcr_42_lzw.tif",
@@ -139,29 +133,6 @@ YCbCr = [
     "ycbcr_44_lzw.tif",
     "ycbcr_24_lzw.tif",
     "ycbcr_12_lzw.tif",
-]
-big_endian = [
-    "int16_big_endian.tif",
-    "rgbsmall_int16_bigendian_lzw_predictor_2.tif",
-    "float32_lzw_predictor_3_big_endian.tif",
-    "quad-lzw-old-style.tif",
-    "separate_tiled.tif",
-    "seperate_strip.tif",
-    "bigtiff_one_strip_be_long8.tif",
-    "bigtiff_four_strip_be_short.tif",
-    "bigtiff_two_strip_be_long8.tif",
-    "contig_strip.tif",
-    "classictiff_four_strip_be_short.tif",
-    "contig_tiled.tif",
-    "bigtiff_one_strip_be_long.tif",
-    "bigtiff_one_block_be_long8.tif",
-    "classictiff_one_strip_be_long.tif",
-    "bigtiff_two_strip_be_long.tif",
-    "classictiff_two_strip_be_short.tif",
-    "classictiff_one_block_be_long.tif",
-    "zackthecat_corrupted.tif",
-    "zackthecat.tif",
-    "cint32_big_endian.tif",
 ]
 slow_tests = [
     "bug1488.tif",
@@ -199,6 +170,8 @@ partial_chunks = [
     "VH.tif",
     "VV.tif",
     "geog_arc_second.tif",
+    "rgbsmall_int16_bigendian_lzw_predictor_2.tif",
+    "quad-lzw-old-style.tif",
 ]
 byte_counts = [
     "VH.tif",
@@ -303,6 +276,8 @@ xfail_reshape = [
     "int12.tif",
     "1bit_2bands.tif",
     "oddsize_1bit2b.tif",
+    "contig_tiled.tif",
+    "separate_tiled.tif",
 ]
 skip = (
     slow_tests

--- a/tests/test_virtual_tiff.py
+++ b/tests/test_virtual_tiff.py
@@ -8,6 +8,7 @@ from obstore.store import LocalStore
 
 failures = {
     "IBCSO_v2_ice-surface_cog.tif": "ValueError: Invalid range requested, start: 0 end: 0",
+    "40613.tif": "Rust panic",
 }
 
 large_files = [


### PR DESCRIPTION
FYI @TomNicholas the dtypes refactor is not actually needed to support big endian files. The dypes are used to specify the in-memory endianness whereas the `endian` parameter in the `Bytes` codec is used to specify the on-disk endianness.