### PR TITLE
refactor: rely on async-tiff's endianness property

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1281,6 +1281,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/4b/195ac84cc8f6077b4f0f421e8daee21b7f1bd88cb7716414234379fe68ec/numcodecs-0.16.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bb/69/96feeac84ce0b871567225c78515f3b557c023e72ed9b4f1833f3662bd6b/obspec-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/9f/34290d64f131ff2d53d698ded79de5226a8b2b01352d99fc7f8a5f5c9b8e/obspec_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d5/9b38c4860187885a7b37a85f5083cdd24afe98c4511985c74bf22c88bfdf/obstore-0.9.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl
@@ -1469,6 +1470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/85/1ac101a40ead81eaa1c7dc49a8827a30e2e436211b43ebdc63c590eb1347/numcodecs-0.16.5-cp311-cp311-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bb/69/96feeac84ce0b871567225c78515f3b557c023e72ed9b4f1833f3662bd6b/obspec-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/9f/34290d64f131ff2d53d698ded79de5226a8b2b01352d99fc7f8a5f5c9b8e/obspec_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/12/fac0b4d1ef1dc1878d9851bdd4088057a041c3c31e16e44a4f8864533e58/obstore-0.9.0-cp311-abi3-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl
@@ -1657,6 +1659,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/cc/0d97ef55dda48cb0f93d7b92d761208e7a99bd2eea6b0e859426e6a99a21/numcodecs-0.16.5-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bb/69/96feeac84ce0b871567225c78515f3b557c023e72ed9b4f1833f3662bd6b/obspec-0.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/9f/34290d64f131ff2d53d698ded79de5226a8b2b01352d99fc7f8a5f5c9b8e/obspec_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/67/229861ae7e1fa3b29493fa96b644d16a0410fc33b5b59de119ad0492c4d6/obstore-0.9.0-cp311-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl
@@ -7875,8 +7878,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: virtual-tiff
-  version: 0.2.2.dev18+g9a2a663af.d20260225
-  sha256: b4939fd6b7e437182fc37eb8ea5925fbde9eecfe33050120a35d701c799fb4c7
+  version: 0.3.2.dev3+g68e19c3a8.d20260409
+  sha256: 63117e8718b5266f26fe0ec7ffd7d28566afac363973d928c817d2d8601529c7
   requires_dist:
   - async-tiff>=0.4.0
   - imagecodecs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
   "s3fs",
   "scipy",
   "earthaccess",
+  "obspec-utils[aiohttp]",
   # docs
   "mkdocs-material[imaging]>=9.6.14",
   "mkdocs>=1.6.1",

--- a/src/virtual_tiff/constants.py
+++ b/src/virtual_tiff/constants.py
@@ -16,7 +16,6 @@ from virtual_tiff.imagecodecs import (
     ZstdCodec,
 )
 
-ENDIAN = {b"MM": "big", b"II": "little"}
 COMPRESSORS = {
     1: None,
     8: Zlib,

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Tuple
 
 import numpy as np
 from async_tiff import TIFF
+from async_tiff.enums import Endianness
 from virtualizarr.manifests import (
     ChunkManifest,
     ManifestArray,
@@ -20,7 +21,7 @@ from zarr.core.sync import sync
 from zarr.dtype import parse_data_type
 
 from virtual_tiff.codecs import ChunkyCodec, HorizontalDeltaCodec
-from virtual_tiff.constants import COMPRESSORS, ENDIAN, GEO_KEYS, SAMPLE_DTYPES
+from virtual_tiff.constants import COMPRESSORS, GEO_KEYS, SAMPLE_DTYPES
 from virtual_tiff.imagecodecs import FloatPredCodec, ZstdCodec
 from virtual_tiff.utils import (
     check_no_partial_strips,
@@ -40,6 +41,10 @@ GDAL_METADATA_TAG = 42112
 GDAL_NODATA_TAG = 42113
 ZSTD_LEVEL_TAG = "65564"
 DEFAULT_ZSTD_LEVEL = 9
+_ENDIANNESS_TO_STR = {
+    Endianness.LittleEndian: "little",
+    Endianness.BigEndian: "big",
+}
 
 
 _MSVC_INF_MAP = {
@@ -424,7 +429,6 @@ def _construct_manifest_group(
     store: ObjectStore,
     path: str,
     *,
-    endian: str,
     ifd: int | None = None,
     ifd_layout: Literal["flat", "nested"] = "flat",
 ) -> ManifestGroup:
@@ -433,7 +437,6 @@ def _construct_manifest_group(
     Args:
         store: Object store for reading the TIFF
         path: Full URL path to the TIFF file
-        endian: Byte order ('little' or 'big')
         ifd: Specific IFD index to process, or None for all IFDs
         ifd_layout: How to organize IFDs - 'flat' for single group, 'nested' for group per IFD
 
@@ -442,6 +445,7 @@ def _construct_manifest_group(
     """
     # TODO: Make an async approach
     tiff = sync(_open_tiff(store=store, path=path))
+    endian = _ENDIANNESS_TO_STR[tiff.endianness]
 
     # Build manifest arrays from selected IFDs
     manifest_arrays = _build_manifest_arrays(tiff, url, endian, ifd)
@@ -549,7 +553,6 @@ class VirtualTIFF:
             ms : ManifestStore containing ChunkManifests and Array metadata for the specified IFDs, along with an ObjectStore instance for loading any data.
         """
         store, path_in_store = registry.resolve(url)
-        endian = ENDIAN[store.get_range(path_in_store, start=0, end=2).to_bytes()]
         async_tiff_store = convert_obstore_to_async_tiff_store(store)
         # Create a group containing dataset level metadata and all the manifest arrays
         manifest_group = _construct_manifest_group(
@@ -557,7 +560,6 @@ class VirtualTIFF:
             store=async_tiff_store,
             path=path_in_store,
             ifd=self._ifd,
-            endian=endian,
             ifd_layout=self.ifd_layout,
         )
         # Convert to a manifest store

--- a/tests/test_http_earthaccess.py
+++ b/tests/test_http_earthaccess.py
@@ -1,0 +1,42 @@
+import earthaccess
+import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
+from obspec_utils.stores import AiohttpStore
+from virtualizarr import open_virtual_dataset
+
+from virtual_tiff import VirtualTIFF
+
+from .conftest import requires_network
+
+
+@requires_network
+def test_load_podaac_http_dataset():
+    """Test loading a PO.DAAC OPERA DSWX-S1 GeoTIFF via HTTP with earthaccess auth."""
+    parser = VirtualTIFF(ifd=0)
+
+    # Get earthaccess token
+    auth = earthaccess.login(strategy="netrc")
+    token = auth.token["access_token"]
+
+    # PO.DAAC Store
+    granule_server = "https://archive.podaac.earthdata.nasa.gov"
+    http_store = AiohttpStore(
+        granule_server,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=60.0,
+    )
+
+    # PO.DAAC Registry
+    http_registry = ObjectStoreRegistry[AiohttpStore]({granule_server: http_store})
+
+    # Construct the file url
+    granule_path = "podaac-ops-cumulus-protected/OPERA_L3_DSWX-S1_V1/OPERA_L3_DSWx-S1_T32UPU_20260326T170644Z_20260327T195326Z_S1C_30_v1.0_B01_WTR.tif"
+    http_file_url = f"{granule_server}/{granule_path}"
+
+    # Open the file as a virtual dataset
+    virtual_http_ds = open_virtual_dataset(
+        url=http_file_url,
+        registry=http_registry,
+        parser=parser,
+    )
+    assert isinstance(virtual_http_ds, xr.Dataset)


### PR DESCRIPTION
Avoid an extra get request by using the endianness property added in async-tiff v0.3.0

fixes #89 