### PR TITLE
chore: use ObjectStoreRegistry from obspec_utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use Virtual TIFF to load data directly:
 
 ```python
 import obstore
-from virtualizarr.registry import ObjectStoreRegistry
+from obspec_utils.registry import ObjectStoreRegistry
 from virtual_tiff import VirtualTIFF
 import xarray as xr
 
@@ -47,7 +47,7 @@ It also works with Google Cloud Storage:
 
 ```python
 import obstore
-from virtualizarr.registry import ObjectStoreRegistry
+from obspec_utils.registry import ObjectStoreRegistry
 from virtual_tiff import VirtualTIFF
 import xarray as xr
 
@@ -70,7 +70,7 @@ or create a virtual dataset:
 ```python
 import obstore
 from virtualizarr import open_virtual_dataset
-from virtualizarr.registry import ObjectStoreRegistry
+from obspec_utils.registry import ObjectStoreRegistry
 from virtual_tiff import VirtualTIFF
 
 # Configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ You can use Virtual TIFF to load data directly:
 
 ```python
 import obstore
-from virtualizarr.registry import ObjectStoreRegistry
+from obspec_utils.registry import ObjectStoreRegistry
 from virtual_tiff import VirtualTIFF
 import xarray as xr
 
@@ -46,7 +46,7 @@ or create a virtual dataset:
 ```python
 import obstore
 from virtualizarr import open_virtual_dataset
-from virtualizarr.registry import ObjectStoreRegistry
+from obspec_utils.registry import ObjectStoreRegistry
 from virtual_tiff import VirtualTIFF
 
 # Configuration

--- a/pixi.lock
+++ b/pixi.lock
@@ -7878,12 +7878,13 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: virtual-tiff
-  version: 0.3.2.dev3+g68e19c3a8.d20260409
-  sha256: 63117e8718b5266f26fe0ec7ffd7d28566afac363973d928c817d2d8601529c7
+  version: 0.3.2.dev8+g25303b195.d20260409
+  sha256: d86cf0cd4b59ea2b230c5b9a481af8e55a290412d557f63d00a09a5e2d57bc8c
   requires_dist:
   - async-tiff>=0.4.0
   - imagecodecs
   - imagecodecs-numcodecs
+  - obspec-utils
   - obstore
   - virtualizarr>=2.0
   - zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 
 dependencies = [
     "obstore",
+    "obspec-utils",
     "async_tiff>=0.4.0",
     "virtualizarr>=2.0",
     "imagecodecs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
   "s3fs",
   "scipy",
   "earthaccess",
-  "obspec-utils[aiohttp]",
   # docs
   "mkdocs-material[imaging]>=9.6.14",
   "mkdocs>=1.6.1",

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Tuple
 
 import numpy as np
 from async_tiff import TIFF
+from obspec_utils.registry import ObjectStoreRegistry
 from virtualizarr.manifests import (
     ChunkManifest,
     ManifestArray,
     ManifestGroup,
     ManifestStore,
 )
-from virtualizarr.registry import ObjectStoreRegistry
 from zarr.abc.codec import BaseCodec
 from zarr.codecs import BytesCodec, TransposeCodec
 from zarr.core.metadata.v3 import ArrayV3Metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 import rioxarray
 import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import LocalStore
-from virtualizarr.registry import ObjectStoreRegistry
 
 from virtual_tiff import VirtualTIFF
 

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -1,7 +1,7 @@
 import os
 
 import obstore
-from virtualizarr.registry import ObjectStoreRegistry
+from obspec_utils.registry import ObjectStoreRegistry
 
 from .conftest import requires_network, rioxarray_comparison
 

--- a/tests/test_gdal_examples.py
+++ b/tests/test_gdal_examples.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 import pytest
+from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import LocalStore
 from packaging.version import Version
 from rioxarray import __version__ as _rioxarray_version
 from virtualizarr import open_virtual_dataset
-from virtualizarr.registry import ObjectStoreRegistry
 
 from virtual_tiff import VirtualTIFF
 

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
+from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import HTTPStore
-from virtualizarr.registry import ObjectStoreRegistry
 
 from .conftest import requires_network, rioxarray_comparison
 

--- a/tests/test_multiband_s3.py
+++ b/tests/test_multiband_s3.py
@@ -1,6 +1,6 @@
 import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import S3Store
-from virtualizarr.registry import ObjectStoreRegistry
 
 from virtual_tiff import VirtualTIFF
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2,8 +2,8 @@ import os
 
 import pytest
 import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import S3Store
-from virtualizarr.registry import ObjectStoreRegistry
 
 from virtual_tiff import VirtualTIFF
 

--- a/tests/test_virtual_tiff.py
+++ b/tests/test_virtual_tiff.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 import rioxarray
 import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import LocalStore
-from virtualizarr.registry import ObjectStoreRegistry
 
 from virtual_tiff import VirtualTIFF
 


### PR DESCRIPTION
PR to avoid deprecation warnings