### PR TITLE
refactor: remove conversion to async-tiff store

### DIFF
--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -25,7 +25,6 @@ from virtual_tiff.constants import COMPRESSORS, GEO_KEYS, SAMPLE_DTYPES
 from virtual_tiff.imagecodecs import FloatPredCodec, ZstdCodec
 from virtual_tiff.utils import (
     check_no_partial_strips,
-    convert_obstore_to_async_tiff_store,
     gdal_metadata_to_dict,
 )
 from virtual_tiff.vendor.xarray.zarr import FillValueCoder
@@ -553,11 +552,10 @@ class VirtualTIFF:
             ms : ManifestStore containing ChunkManifests and Array metadata for the specified IFDs, along with an ObjectStore instance for loading any data.
         """
         store, path_in_store = registry.resolve(url)
-        async_tiff_store = convert_obstore_to_async_tiff_store(store)
         # Create a group containing dataset level metadata and all the manifest arrays
         manifest_group = _construct_manifest_group(
             url,
-            store=async_tiff_store,
+            store=store,
             path=path_in_store,
             ifd=self._ifd,
             ifd_layout=self.ifd_layout,

--- a/src/virtual_tiff/utils.py
+++ b/src/virtual_tiff/utils.py
@@ -1,24 +1,6 @@
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING
-
-from async_tiff.store import AzureStore, GCSStore, HTTPStore, LocalStore, S3Store
-from obstore.store import ObjectStore
-
-if TYPE_CHECKING:
-    from async_tiff.store import ObjectStore as AsyncTiffObjectStore
-    from obstore.store import (
-        ObjectStore,
-    )
-
-store_matching = {
-    "LocalStore": LocalStore,
-    "AzureStore": AzureStore,
-    "S3Store": S3Store,
-    "GCSStore": GCSStore,
-    "HTTPStore": HTTPStore,
-}
 
 
 def gdal_metadata_to_dict(xml_string: str) -> dict[str, str]:
@@ -33,17 +15,6 @@ def gdal_metadata_to_dict(xml_string: str) -> dict[str, str]:
             value = item.text.strip() if item.text else ""
             metadata_dict[name] = value
     return metadata_dict
-
-
-def convert_obstore_to_async_tiff_store(store: ObjectStore) -> AsyncTiffObjectStore:
-    """
-    We need to use an async_tiff ObjectStore instance rather than an ObjectStore instance for opening and parsing the TIFF file,
-    so that the store isn't passed through Python.
-    """
-
-    newargs = store.__getnewargs_ex__()
-    name = store.__class__.__name__
-    return store_matching[name](*newargs[0], **newargs[1])
 
 
 def check_no_partial_strips(image_height: int, rows_per_strip: int):


### PR DESCRIPTION
This removes the conversion from a generic obtore/obspec-compliant store to an AsyncTIFF store. This may have a slight performance hit, but allows much more flexibility with store wrappers and simplifies the code base. It's needed for https://github.com/NASA-IMPACT/virtual-zarr-converage and #95 