### PR TITLE
fix: decode LZW strips/tiles written without an EOI code

### DIFF
--- a/src/virtual_tiff/imagecodecs.py
+++ b/src/virtual_tiff/imagecodecs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import (
@@ -204,6 +205,36 @@ class LercCodec(_ImageCodecsBytesBytesCodec):
 
 class LZWCodec(_ImageCodecsBytesBytesCodec):
     codec_name = "imagecodecs_lzw"
+
+    def _decode(
+        self, chunk_bytes: Buffer, prototype: BufferPrototype, nbytes: int
+    ) -> Buffer:
+        # imagecodecs returns a view of only the bytes it wrote, so a short
+        # result is the only signal that the stream didn't fill the chunk.
+        out = np.zeros(nbytes, dtype=np.uint8)
+        decoded = memoryview(self._codec.decode(chunk_bytes.as_numpy_array(), out=out))
+        if len(decoded) != nbytes:
+            raise ValueError(
+                f"{self.codec_name} decoded {len(decoded)} bytes, expected {nbytes}: "
+                "the compressed stream is truncated or corrupt."
+            )
+        return prototype.buffer.from_bytes(decoded)
+
+    async def _decode_single(
+        self, chunk_bytes: Buffer, chunk_spec: ArraySpec
+    ) -> Buffer:
+        # TIFF requires every LZW strip/tile to end in an End-Of-Information
+        # code, but some writers omit it. Without one, the size pre-scan
+        # imagecodecs runs when it isn't given an output size decodes the
+        # trailing padding as extra codes and either over-estimates or raises
+        # IMCD_LZW_CORRUPT. Passing the size skips the pre-scan, as tifffile
+        # does; the cost is that an over-long stream is silently truncated.
+        nbytes = (
+            math.prod(chunk_spec.shape) * chunk_spec.dtype.to_native_dtype().itemsize
+        )
+        return await asyncio.to_thread(
+            self._decode, chunk_bytes, chunk_spec.prototype, nbytes
+        )
 
 
 class PackBitsCodec(_ImageCodecsBytesBytesCodec):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from urllib.parse import urlparse
 
+import imagecodecs
 import numpy as np
 import pytest
 import rioxarray
@@ -11,6 +12,52 @@ from obstore.store import LocalStore
 from virtual_tiff import VirtualTIFF
 
 requires_network = pytest.mark.network
+
+LZW_CLEAR_CODE = 256
+LZW_EOI_CODE = 257
+
+
+def lzw_encode_literals(
+    data: bytes, *, with_eoi: bool = True, trailing: bytes = b""
+) -> bytes:
+    """Encode ``data`` as a TIFF-LZW stream of 9-bit literal codes.
+
+    A clear code every 200 bytes keeps the dictionary below 512 entries, so every
+    code stays 9 bits wide and the encoder needs no code-width logic.
+    """
+    out = bytearray()
+    acc = nbits = 0
+
+    def write(code: int) -> None:
+        nonlocal acc, nbits
+        acc = (acc << 9) | code
+        nbits += 9
+        while nbits >= 8:
+            nbits -= 8
+            out.append((acc >> nbits) & 0xFF)
+        acc &= (1 << nbits) - 1
+
+    write(LZW_CLEAR_CODE)
+    since_clear = 0
+    for byte in data:
+        if since_clear >= 200:
+            write(LZW_CLEAR_CODE)
+            since_clear = 0
+        write(byte)
+        since_clear += 1
+    if with_eoi:
+        write(LZW_EOI_CODE)
+    if nbits:  # pad the final byte with zero bits
+        out.append((acc << (8 - nbits)) & 0xFF)
+    return bytes(out) + trailing
+
+
+def lzw_unsized_decode_fails(stream: bytes, nbytes: int) -> bool:
+    """Whether imagecodecs mis-decodes ``stream`` when not told the output size."""
+    try:
+        return len(imagecodecs.lzw_decode(stream)) != nbytes
+    except imagecodecs.LzwError:
+        return True
 
 
 # Pytest configuration

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -30,6 +30,8 @@ from virtual_tiff.parser import (
     _get_compression,
 )
 
+from .conftest import lzw_encode_literals, lzw_unsized_decode_fails
+
 _DEFAULT_CONFIG = ArrayConfig(order="C", write_empty_chunks=True)
 
 
@@ -572,3 +574,56 @@ class TestHorizontalDeltaFloat:
         spec = _make_spec((1, 3), UInt16())
         result = await codec._decode_single(nd_buf, spec)
         np.testing.assert_array_equal(result.as_ndarray_like(), original)
+
+
+class TestLZWWithoutEOI:
+    """TIFF 6.0 requires every LZW strip/tile to end with an End-Of-Information
+    code, but some writers omit it (e.g. GLAD's annual class maps). Decoding into
+    a correctly sized buffer skips the size pre-scan that then misreads the
+    stream's trailing padding.
+    """
+
+    SHAPE = (256, 256)
+    NBYTES = 256 * 256
+
+    @staticmethod
+    def _payload(nbytes: int) -> bytes:
+        return ((np.arange(nbytes) * 7 + 13) % 256).astype(np.uint8).tobytes()
+
+    @staticmethod
+    async def _decode(raw: bytes, spec: ArraySpec) -> bytes:
+        buf = default_buffer_prototype().buffer.from_bytes(raw)
+        decoded = await LZWCodec()._decode_single(buf, spec)
+        return decoded.to_bytes()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "trailing,dtype,itemsize",
+        [
+            # Zero pad bytes decode as phantom codes, so the unsized decode
+            # over-emits; 0xff pad bytes make its pre-scan raise IMCD_LZW_CORRUPT
+            # before any output buffer exists, which is why truncating after the
+            # fact cannot fix those tiles.
+            (b"\x00\x00", UInt8(), 1),
+            (b"\xff\xff", UInt8(), 1),
+            # The size has to account for the dtype's item size, not just the
+            # element count.
+            (b"\x00\x00", UInt16(), 2),
+        ],
+        ids=["zero-pad", "ff-pad", "uint16"],
+    )
+    async def test_missing_eoi_decodes(self, trailing, dtype, itemsize):
+        nbytes = self.NBYTES * itemsize
+        original = self._payload(nbytes)
+        raw = lzw_encode_literals(original, with_eoi=False, trailing=trailing)
+        assert lzw_unsized_decode_fails(raw, nbytes)
+
+        assert await self._decode(raw, _make_spec(self.SHAPE, dtype)) == original
+
+    @pytest.mark.asyncio
+    async def test_truncated_stream_raises(self):
+        """A stream decoding to fewer bytes than the chunk needs must raise rather
+        than return a chunk whose tail is zero padding the file never held."""
+        raw = lzw_encode_literals(self._payload(1000), with_eoi=True)
+        with pytest.raises(ValueError, match="1000 bytes.*expected 65536"):
+            await self._decode(raw, _make_spec(self.SHAPE, UInt8()))

--- a/tests/test_lzw_missing_eoi_https.py
+++ b/tests/test_lzw_missing_eoi_https.py
@@ -1,0 +1,83 @@
+"""Real-file coverage for LZW tiles written without an End-Of-Information code.
+
+GLAD/UMD's annual class maps are 256x256-tiled LZW BigTIFFs in which a handful of
+tile streams omit the EOI code TIFF 6.0 requires. This is the only test that runs
+the fix against real streams: the offline ones are built from 9-bit literal codes,
+so nothing there exercises a grown dictionary or TIFF's early-change code widths.
+"""
+
+import math
+from urllib.parse import urlparse
+
+import numpy as np
+import pytest
+import xarray as xr
+from obspec_utils.registry import ObjectStoreRegistry
+from obstore.store import HTTPStore
+from zarr.core.sync import sync
+
+from virtual_tiff import VirtualTIFF
+from virtual_tiff.parser import _open_tiff
+
+from .conftest import requires_network
+
+URL = "https://glad.umd.edu/projects/AnnualClassMapsV1/SouthAmerica_Soybean_2020.tif"
+
+# Tiles whose LZW streams carry no EOI code: 322502 used to make the size pre-scan
+# over-emit by 4 bytes, 123609 to make it raise IMCD_LZW_CORRUPT.
+TILES_MISSING_EOI = (322502, 123609)
+
+# The geometry those tile indices were recorded against, checked against the file.
+EXPECTED_TILE = 256
+EXPECTED_TILES_ACROSS = 751  # ceil(192004 / 256)
+
+
+@pytest.fixture(scope="module")
+def registry() -> ObjectStoreRegistry:
+    parsed = urlparse(URL)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    return ObjectStoreRegistry({base: HTTPStore.from_url(base)})
+
+
+@pytest.fixture(scope="module")
+def geometry(registry: ObjectStoreRegistry) -> tuple[int, int]:
+    """Tile size and tile-grid width, read from the file rather than assumed.
+
+    A tile index only identifies a window under the geometry it was recorded
+    against, so if the source file is ever republished at a different width or
+    tile size these tests must fail rather than compare an unaffected window.
+    """
+    store, path = registry.resolve(URL)
+    ifd = sync(_open_tiff(store=store, path=path)).ifds[0]
+    assert ifd.tile_width == ifd.tile_height == EXPECTED_TILE
+    assert ifd.samples_per_pixel == 1 and tuple(ifd.bits_per_sample) == (8,)
+    tiles_across = math.ceil(ifd.image_width / ifd.tile_width)
+    assert tiles_across == EXPECTED_TILES_ACROSS
+    return ifd.tile_width, tiles_across
+
+
+@requires_network
+@pytest.mark.parametrize("tile_index", TILES_MISSING_EOI)
+def test_lzw_tile_without_eoi_matches_gdal(registry, geometry, tile_index):
+    """Reading an EOI-less tile through the full parser -> zarr -> xarray stack
+    returns the same pixels GDAL reads from the same window."""
+    rasterio = pytest.importorskip("rasterio")
+    from rasterio.windows import Window
+
+    tile, tiles_across = geometry
+    ds = xr.open_zarr(
+        VirtualTIFF(ifd=0)(URL, registry=registry),
+        zarr_format=3,
+        consolidated=False,
+        chunks=None,
+        mask_and_scale=False,
+    )
+
+    row, col = divmod(tile_index, tiles_across)  # TIFF mandates row-major tiles
+    y0, x0 = row * tile, col * tile
+    actual = np.asarray(ds["0"][y0 : y0 + tile, x0 : x0 + tile])
+
+    with rasterio.open(URL) as src:
+        expected = src.read(1, window=Window(x0, y0, tile, tile))
+
+    np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
I caught this one in the wild after virtualising some GLAD datasets and started getting `LZW` decode errors. My understanding is that TIFF 6.0 requires every strip/tile to end with an End-Of-Information code, but it seems like its not uncommon for some writers to omit it.

Without it imagecodecs decodes the trailing padding as extra, or raises an `IMCD_LZW_CORRUPT`.

My attempted fix means we now compute the expected chunk size from `ArraySpec` and passes it to `imagecodecs`, which means we skip the scan causing the error, I think this is the same approach`tifffile` takes. The tradeoff is that an over-long stream can be truncated without a warning. A short result still raises a ValueError.

Two types of test, admittedly the latter is more AI driven than my own, as its on the edge of my knowledge, happy to drop it but its the only test that covers the short stream path, the network test captures the regression on a live file:

- `test_lzw_missing_eoi_https` reads two tiles lacking EOIs from the GLAD annual class map and compares against GDAL
- `test_codecs` is the offline test, it builds the streams from 9-bit literal codes with no EOI code, and asserts they either fail or raise ValueError on a short stream.

Opening as a draft as its my first look at codecs, @maxrjones happy for you to tear apart or if you'd prefer me to raise as an issue go ahead, I've got a fork that I've pinned to for our production use.