### PR TITLE
fix: represent ChunkyCodec endianness as a plain string

### DIFF
--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -13,7 +13,6 @@ from zarr.abc.codec import (
     CodecJSON_V2,
     CodecJSON_V3,
 )
-from zarr.codecs.bytes import Endian
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
 from zarr.core.common import JSON
 from zarr.registry import register_codec
@@ -28,14 +27,18 @@ def check_codecjson_v2(data: object) -> bool:
 
 ZarrFormat = Literal[2, 3]
 
+EndianLiteral = Literal["little", "big"]
 
-def _parse_endian(data: object) -> Endian | None:
+
+def _parse_endian(data: object) -> EndianLiteral | None:
     if data is None:
         return None
-    if isinstance(data, Endian):
-        return data
-    if isinstance(data, str) and data in ("little", "big"):
-        return Endian(data)
+    if isinstance(data, str):
+        # `str.__str__` bypasses `Enum.__str__`, so str-subclass enum members such as
+        # zarr's deprecated `Endian` normalise to their underlying string.
+        value = str.__str__(data)
+        if value in ("little", "big"):
+            return cast(EndianLiteral, value)
     raise ValueError(
         f"Invalid endian value: {data!r}. Expected 'little', 'big', or None."
     )
@@ -45,9 +48,9 @@ def _parse_endian(data: object) -> Endian | None:
 class ChunkyCodec(ArrayBytesCodec):
     is_fixed_size = True
 
-    endian: Endian | None
+    endian: EndianLiteral | None
 
-    def __init__(self, *, endian: Endian | str | None = "little") -> None:
+    def __init__(self, *, endian: str | None = "little") -> None:
         object.__setattr__(self, "endian", _parse_endian(endian))
 
     @classmethod
@@ -86,13 +89,13 @@ class ChunkyCodec(ArrayBytesCodec):
     def to_json(self, zarr_format: ZarrFormat) -> CodecJSON_V2 | CodecJSON_V3:
         if zarr_format == 2:
             if self.endian is not None:
-                return {"id": "ChunkyCodec", "endian": self.endian.value}  # type: ignore[return-value, typeddict-item]
+                return {"id": "ChunkyCodec", "endian": self.endian}  # type: ignore[return-value, typeddict-item]
             return {"id": "ChunkyCodec"}  # type: ignore[return-value]
         elif zarr_format == 3:
             if self.endian is not None:
                 return {
                     "name": "ChunkyCodec",
-                    "configuration": {"endian": self.endian.value},
+                    "configuration": {"endian": self.endian},
                 }
             return {"name": "ChunkyCodec"}
         raise ValueError(
@@ -116,7 +119,7 @@ class ChunkyCodec(ArrayBytesCodec):
     ) -> NDBuffer:
         assert isinstance(chunk_bytes, Buffer)
         if chunk_spec.dtype.item_size > 0:
-            if self.endian == Endian.little:
+            if self.endian == "little":
                 prefix = "<"
             else:
                 prefix = ">"
@@ -155,7 +158,7 @@ class ChunkyCodec(ArrayBytesCodec):
         ):
             # type-ignore is a numpy bug
             # see https://github.com/numpy/numpy/issues/26473
-            new_dtype = chunk_array.dtype.newbyteorder(self.endian.name)  # type: ignore[arg-type]
+            new_dtype = chunk_array.dtype.newbyteorder(self.endian)  # type: ignore[arg-type]
             chunk_array = chunk_array.astype(new_dtype)
 
         nd_array = chunk_array.as_ndarray_like()

--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -30,15 +30,24 @@ ZarrFormat = Literal[2, 3]
 EndianLiteral = Literal["little", "big"]
 
 
+def _unwrap_endian(data: object) -> object:
+    """Reduce an endianness value to a plain string where possible.
+
+    zarr has spelled this as a plain `Enum`, as a str-subclass enum, and now as a
+    bare string, and we accept all three. Plain enums yield their `value`;
+    `str.__str__` bypasses `Enum.__str__`, which would otherwise render a
+    str-subclass member as "Endian.big".
+    """
+    data = getattr(data, "value", data)
+    return str.__str__(data) if isinstance(data, str) else data
+
+
 def _parse_endian(data: object) -> EndianLiteral | None:
     if data is None:
         return None
-    if isinstance(data, str):
-        # `str.__str__` bypasses `Enum.__str__`, so str-subclass enum members such as
-        # zarr's deprecated `Endian` normalise to their underlying string.
-        value = str.__str__(data)
-        if value in ("little", "big"):
-            return cast(EndianLiteral, value)
+    value = _unwrap_endian(data)
+    if value in ("little", "big"):
+        return cast(EndianLiteral, value)
     raise ValueError(
         f"Invalid endian value: {data!r}. Expected 'little', 'big', or None."
     )
@@ -154,7 +163,9 @@ class ChunkyCodec(ArrayBytesCodec):
         if (
             chunk_array.dtype.itemsize > 1
             and self.endian is not None
-            and self.endian != chunk_array.byteorder
+            # older zarr reports `byteorder` as an enum member, which never compares
+            # equal to a plain string
+            and self.endian != _unwrap_endian(chunk_array.byteorder)
         ):
             # type-ignore is a numpy bug
             # see https://github.com/numpy/numpy/issues/26473

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 import numpy as np
 import pytest
 import rioxarray
-import tifffile
 import xarray as xr
 from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import LocalStore
@@ -51,13 +50,25 @@ def chunky_rgb_file(tmp_path: Path) -> str:
     """
     filepath = tmp_path / "chunky_rgb.tif"
     rng = np.random.default_rng(0)
-    data = rng.integers(0, 256, size=(64, 64, 3), dtype="uint8")
-    tifffile.imwrite(
-        filepath,
+    data = rng.integers(0, 256, size=(3, 64, 64), dtype="uint8")
+    # Real coords, so rioxarray writes a geotransform rather than warning about
+    # falling back to the identity matrix.
+    da = xr.DataArray(
         data,
-        photometric="rgb",
-        planarconfig="contig",
-        tile=(16, 16),
+        dims=("band", "y", "x"),
+        coords={
+            "band": [1, 2, 3],
+            "y": 1000.0 - 10.0 * np.arange(64),
+            "x": 500.0 + 10.0 * np.arange(64),
+        },
+    )
+    da.rio.to_raster(
+        filepath,
+        driver="GTiff",
+        INTERLEAVE="PIXEL",
+        TILED="YES",
+        BLOCKXSIZE=16,
+        BLOCKYSIZE=16,
     )
     return str(filepath)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import numpy as np
 import pytest
 import rioxarray
+import tifffile
 import xarray as xr
 from obspec_utils.registry import ObjectStoreRegistry
 from obstore.store import LocalStore
@@ -37,6 +38,27 @@ def geotiff_file(tmp_path: Path) -> str:
     filepath = tmp_path / "air.tif"
     with xr.tutorial.open_dataset("air_temperature") as ds:
         ds.isel(time=0).rio.to_raster(filepath, driver="COG", COMPRESS="DEFLATE")
+    return str(filepath)
+
+
+@pytest.fixture
+def chunky_rgb_file(tmp_path: Path) -> str:
+    """Create a tiled, pixel-interleaved (PlanarConfiguration=1) RGB TIFF.
+
+    This exercises the chunky codec path, which needs samples_per_pixel > 1
+    *and* planar_configuration == 1 -- the separate-planes multi-band tests
+    take a different branch.
+    """
+    filepath = tmp_path / "chunky_rgb.tif"
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 256, size=(64, 64, 3), dtype="uint8")
+    tifffile.imwrite(
+        filepath,
+        data,
+        photometric="rgb",
+        planarconfig="contig",
+        tile=(16, 16),
+    )
     return str(filepath)
 
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -16,6 +16,7 @@ from virtual_tiff.codecs import (
     ChunkyCodec,
     HorizontalDeltaCodec,
     _parse_endian,
+    _unwrap_endian,
     check_codecjson_v2,
 )
 from virtual_tiff.imagecodecs import (
@@ -110,16 +111,31 @@ def test_parse_endian_string_big():
     assert _parse_endian("big") == "big"
 
 
-def test_parse_endian_normalises_str_enum():
-    # Callers may still pass a str-subclass enum member, e.g. zarr's deprecated
-    # `Endian`. It should come back as a plain str so `.value`-free code works.
-    class Endian(str, Enum):
-        little = "little"
-        big = "big"
+class _StrEndian(str, Enum):
+    little = "little"
+    big = "big"
 
-    parsed = _parse_endian(Endian.big)
+
+class _PlainEndian(Enum):
+    little = "little"
+    big = "big"
+
+
+# zarr has spelled Endian as a plain enum, a str-subclass enum, and a bare string
+# across versions, and callers may still hand us any of them.
+@pytest.mark.parametrize("member", [_StrEndian.big, _PlainEndian.big])
+def test_parse_endian_normalises_enum(member):
+    parsed = _parse_endian(member)
     assert parsed == "big"
     assert type(parsed) is str
+
+
+@pytest.mark.parametrize("member", [_StrEndian.little, _PlainEndian.little, "little"])
+def test_unwrap_endian_compares_equal_to_string(member):
+    """The encode path compares `self.endian` against `NDBuffer.byteorder`, which
+    older zarr reports as an enum member. Unwrapping keeps that comparison
+    meaningful instead of always reporting a mismatch."""
+    assert _unwrap_endian(member) == "little"
 
 
 def test_parse_endian_invalid():

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 import numpy as np
 import pytest
-from zarr.codecs.bytes import Endian
 from zarr.core.array_spec import ArrayConfig, ArraySpec
 from zarr.core.buffer import default_buffer_prototype
 from zarr.core.buffer.cpu import NDBuffer
@@ -103,15 +103,23 @@ def test_parse_endian_none():
 
 
 def test_parse_endian_string_little():
-    assert _parse_endian("little") == Endian.little
+    assert _parse_endian("little") == "little"
 
 
 def test_parse_endian_string_big():
-    assert _parse_endian("big") == Endian.big
+    assert _parse_endian("big") == "big"
 
 
-def test_parse_endian_enum_passthrough():
-    assert _parse_endian(Endian.big) is Endian.big
+def test_parse_endian_normalises_str_enum():
+    # Callers may still pass a str-subclass enum member, e.g. zarr's deprecated
+    # `Endian`. It should come back as a plain str so `.value`-free code works.
+    class Endian(str, Enum):
+        little = "little"
+        big = "big"
+
+    parsed = _parse_endian(Endian.big)
+    assert parsed == "big"
+    assert type(parsed) is str
 
 
 def test_parse_endian_invalid():
@@ -129,7 +137,7 @@ def test_parse_endian_invalid_type():
 
 def test_chunky_codec_default_endian():
     codec = ChunkyCodec()
-    assert codec.endian == Endian.little
+    assert codec.endian == "little"
 
 
 @pytest.mark.parametrize("endian", ["big", "little"])
@@ -187,7 +195,7 @@ def test_chunky_codec_none_endian_to_json_v2():
 def test_chunky_codec_from_json_v3_string_only():
     """A v3 codec can be just a name string with no configuration."""
     restored = ChunkyCodec._from_json_v3("ChunkyCodec")
-    assert restored.endian == Endian.little  # default
+    assert restored.endian == "little"  # default
 
 
 def test_chunky_codec_from_json_v2_invalid():
@@ -240,14 +248,14 @@ def test_chunky_codec_evolve_from_array_spec_single_byte():
     """endian should be preserved for single-byte dtypes (item_size > 0)."""
     codec = ChunkyCodec(endian="little")
     evolved = codec.evolve_from_array_spec(_make_spec((10,), UInt8()))
-    assert evolved.endian == Endian.little
+    assert evolved.endian == "little"
 
 
 def test_chunky_codec_evolve_from_array_spec_multi_byte():
     """endian should be preserved for multi-byte dtypes."""
     codec = ChunkyCodec(endian="big")
     evolved = codec.evolve_from_array_spec(_make_spec((10,), UInt16()))
-    assert evolved.endian == Endian.big
+    assert evolved.endian == "big"
 
 
 def test_chunky_codec_evolve_from_array_spec_none_endian_multi_byte():

--- a/tests/test_virtual_tiff.py
+++ b/tests/test_virtual_tiff.py
@@ -39,6 +39,20 @@ def test_simple_load_dataset_against_rioxarray(geotiff_file, mask_and_scale):
     np.testing.assert_allclose(observed.data.squeeze(), expected.data.squeeze())
 
 
+def test_chunky_rgb_load_against_rioxarray(chunky_rgb_file):
+    """Pixel-interleaved multi-band TIFFs go through ChunkyCodec.
+
+    Regression test for the endian handling in that codec, which used to raise
+    on construction rather than produce a manifest.
+    """
+    registry = ObjectStoreRegistry({"file://": LocalStore()})
+    ds = loadable_dataset(f"file://{chunky_rgb_file}", registry=registry)
+    assert isinstance(ds, xr.Dataset)
+    assert ds["0"].sizes["band"] == 3
+    expected = rioxarray.open_rasterio(chunky_rgb_file)
+    np.testing.assert_array_equal(ds["0"].data.squeeze(), expected.data.squeeze())
+
+
 @pytest.mark.parametrize("mask_and_scale", [True, False])
 @pytest.mark.parametrize("filename", github_examples())
 def test_load_dataset_against_rioxarray(filename, mask_and_scale):


### PR DESCRIPTION
Fixes #105.

## Problem

`virtual_tiff/codecs.py` imported `Endian` from `zarr.codecs.bytes`. zarr has since replaced that name with a deprecation shim (metaclass `_DeprecatedStrEnumMeta`) that is no longer constructible:

```python
>>> from zarr.codecs.bytes import Endian
>>> Endian("little")
TypeError: Endian() takes no arguments
```

So `_parse_endian` raised for any string input, and every pixel-interleaved multi-band TIFF failed to virtualize. Only the chunky branch was affected — `_get_codecs` builds a `ChunkyCodec` just when `planar_configuration == 1 and samples_per_pixel > 1`; single-band files pass the string to zarr's own `BytesCodec`, which still parses it.

## Fix

Drop the enum rather than reintroduce a local one. zarr now models this as `EndianLiteral = Literal["little", "big"]` and returns a bare `str` from `NDBuffer.byteorder`, so plain strings follow upstream instead of recreating a type zarr is retiring — and it drops a dependency on an already-deprecated zarr name.

Accepting an endianness value from a caller then has to cope with all three spellings zarr has used, so `_unwrap_endian` handles each:

- **bare string** (current zarr) — used as-is
- **plain `Enum`** (zarr 3.1.5) — reduced via `.value`. Note `Endian.little == "little"` is `False` for these, so comparing against a string without unwrapping both rejects the member in `_parse_endian` *and* makes `_encode_single`'s `byteorder` check always report a mismatch, copying the array on every encode.
- **str-subclass enum** — reduced via `str.__str__`, since plain `str()` would render the member as `"Endian.big"` (`Enum.__str__` takes precedence).

The serialized `endian` value is unchanged in v2 and v3 output, so existing metadata still round-trips.

## Test coverage

The reason CI didn't catch this: both existing multi-band tests use `PlanarConfiguration=2` (separate planes, the working branch) **and** are network-gated. The chunky path had no coverage at all.

Added `chunky_rgb_file` — a 64×64 tiled pixel-interleaved RGB TIFF written with `rio.to_raster(..., INTERLEAVE="PIXEL")`, using rioxarray/rasterio from the existing pixi `test` feature rather than adding a dependency. Confirmed via async-tiff that the result really does hit the intended path: `samples_per_pixel=3`, `planar_configuration=1`, 16×16 tiles. Verified the test fails with `TypeError: Endian() takes no arguments` when the `codecs.py` change is reverted.

`_parse_endian`/`_unwrap_endian` tests now parametrise over both enum spellings plus a bare string.

## Verification

On zarr 3.3.0:

| check | before | after |
|---|---|---|
| offline test suite | 20 failed / 159 passed | 0 failed / 182 passed* |
| mypy on `codecs.py` | 10 errors | 5 errors |
| 289 real Sentinel-2 COGs | 34 fail | 289 ok, 68,731 chunk refs |

\* excluding 2 failures pre-existing on clean `main` (`test_geo_key_attributes_are_not_booleans`, `test_local_store_with_prefix`), both from test data absent locally. The 5 remaining mypy errors are likewise pre-existing and unrelated (`item_size`, `cumsum`, `object` args). Pre-commit — ruff, ruff format, codespell, mypy — passes.

Also run against **zarr 3.1.5** in a separate environment, which is what CI installs (see below): same result, no regression in either direction.

Found this while virtualizing a month of Sentinel-2 L2A (`s3://sentinel-cogs/sentinel-s2-l2a-cogs/10/S/EG/2026/6`): 34 of 289 COGs failed, exactly the `TCI.tif` and `L2A_PVI.tif` RGB files across 17 scenes.

## Follow-up worth considering separately

`pixi.lock` pins **zarr 3.1.5**, and it is the only zarr in the lockfile — `test-min-versions` pins `xarray`/`virtualizarr`/`async_tiff` but takes zarr from the lock like everything else. So no CI environment has run the zarr that exhibits this bug, which is why `main` stays green daily while anyone installing from PyPI hits it immediately.

That means a green run on this PR does not by itself demonstrate the fix; the 3.3.0 environment above is what does. Refreshing the lock (or adding an environment that resolves zarr fresh) would close the gap, but it pulls in unrelated upgrades, so I have left `pyproject.toml` and `pixi.lock` untouched here.
