### PR TITLE
SubIFD support for OME-TIFF microscopy images with pyramid levels

### DIFF
--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -96,10 +96,10 @@ class ChunkyCodec(ArrayBytesCodec):
         elif zarr_format == 3:
             if self.endian is not None:
                 return {
-                    "name": "ChunkyCodec",
+                    "name": "virtual_tiff.ChunkyCodec",
                     "configuration": {"endian": self.endian},
                 }
-            return {"name": "ChunkyCodec"}
+            return {"name": "virtual_tiff.ChunkyCodec"}
         raise ValueError(
             f"Unsupported Zarr format {zarr_format}. Expected 2 or 3."
         )  # pragma: no cover
@@ -211,7 +211,7 @@ class HorizontalDeltaCodec(ArrayArrayCodec):
         if zarr_format == 2:
             return {"id": "HorizontalDeltaCodec"}  # type: ignore[return-value]
         elif zarr_format == 3:
-            return {"name": "HorizontalDeltaCodec"}
+            return {"name": "virtual_tiff.HorizontalDeltaCodec"}
         raise ValueError(
             f"Unsupported Zarr format {zarr_format}. Expected 2 or 3."
         )  # pragma: no cover
@@ -253,5 +253,7 @@ class HorizontalDeltaCodec(ArrayArrayCodec):
         return input_byte_length
 
 
-register_codec("ChunkyCodec", ChunkyCodec)
-register_codec("HorizontalDeltaCodec", HorizontalDeltaCodec)
+# The same names the `zarr.codecs` entry points publish, so a reader that only opens the array --
+# having never imported this package -- resolves the codec an array was written with.
+register_codec("virtual_tiff.ChunkyCodec", ChunkyCodec)
+register_codec("virtual_tiff.HorizontalDeltaCodec", HorizontalDeltaCodec)

--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -32,12 +32,10 @@ EndianLiteral = Literal["little", "big"]
 
 
 def _parse_endian(data: object) -> EndianLiteral | None:
-    """Endianness as the literal string, whatever the caller holds.
+    """Endianness as the literal string.
 
-    zarr 3.3 turned ``zarr.codecs.bytes.Endian`` into a deprecation shim — a class with no members
-    and no constructor, whose member access returns the equivalent string. Earlier zarr versions
-    still ship it as a real enum, so ``getattr`` below unwraps a member from either era to its
-    string value.
+    ``getattr`` unwraps an ``Endian`` enum member from zarr before 3.3; from 3.3 on, the
+    deprecation shim's member access already returns the string.
     """
     if data is None:
         return None
@@ -256,7 +254,7 @@ class HorizontalDeltaCodec(ArrayArrayCodec):
         return input_byte_length
 
 
-# The same names the `zarr.codecs` entry points publish, so a reader that only opens the array --
-# having never imported this package -- resolves the codec an array was written with.
+# The names the `zarr.codecs` entry points publish, so readers that never import this package
+# still resolve the codecs.
 register_codec("virtual_tiff.ChunkyCodec", ChunkyCodec)
 register_codec("virtual_tiff.HorizontalDeltaCodec", HorizontalDeltaCodec)

--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -33,7 +33,7 @@ def _parse_endian(data: object) -> str | None:
     if data is None:
         return None
     if isinstance(data, Endian):
-        # zarr before 3.3; the 3.3 shim's member access already returns the string.
+        # zarr before 3.3; the 3.3 adapter's member access already returns the string.
         return data.value
     if isinstance(data, str) and data in ("little", "big"):
         return data

--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -13,6 +13,7 @@ from zarr.abc.codec import (
     CodecJSON_V2,
     CodecJSON_V3,
 )
+from zarr.codecs.bytes import Endian
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
 from zarr.core.common import JSON
 from zarr.registry import register_codec
@@ -27,21 +28,15 @@ def check_codecjson_v2(data: object) -> bool:
 
 ZarrFormat = Literal[2, 3]
 
-# The literal strings the zarr 3 spec uses for the bytes codec's endian configuration.
-EndianLiteral = Literal["little", "big"]
 
-
-def _parse_endian(data: object) -> EndianLiteral | None:
-    """Endianness as the literal string.
-
-    ``getattr`` unwraps an ``Endian`` enum member from zarr before 3.3; from 3.3 on, the
-    deprecation shim's member access already returns the string.
-    """
+def _parse_endian(data: object) -> str | None:
     if data is None:
         return None
-    data = getattr(data, "value", data)
+    if isinstance(data, Endian):
+        # zarr before 3.3; the 3.3 shim's member access already returns the string.
+        return data.value
     if isinstance(data, str) and data in ("little", "big"):
-        return cast("EndianLiteral", data)
+        return data
     raise ValueError(
         f"Invalid endian value: {data!r}. Expected 'little', 'big', or None."
     )
@@ -51,7 +46,7 @@ def _parse_endian(data: object) -> EndianLiteral | None:
 class ChunkyCodec(ArrayBytesCodec):
     is_fixed_size = True
 
-    endian: EndianLiteral | None
+    endian: str | None
 
     def __init__(self, *, endian: str | None = "little") -> None:
         object.__setattr__(self, "endian", _parse_endian(endian))

--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -13,7 +13,6 @@ from zarr.abc.codec import (
     CodecJSON_V2,
     CodecJSON_V3,
 )
-from zarr.codecs.bytes import EndianLiteral
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
 from zarr.core.common import JSON
 from zarr.registry import register_codec
@@ -28,17 +27,21 @@ def check_codecjson_v2(data: object) -> bool:
 
 ZarrFormat = Literal[2, 3]
 
+# The literal strings the zarr 3 spec uses for the bytes codec's endian configuration.
+EndianLiteral = Literal["little", "big"]
+
 
 def _parse_endian(data: object) -> EndianLiteral | None:
-    """Endianness as zarr 3.3 wants it: the literal string.
+    """Endianness as the literal string, whatever the caller holds.
 
-    ``zarr.codecs.bytes.Endian`` is a deprecation shim there — a class with no members and no
-    constructor — so ``Endian("little")`` raises ``TypeError: Endian() takes no arguments``.
-    Accessing a member of it returns the equivalent string, so a caller passing ``Endian.little``
-    still lands in the string branch below.
+    zarr 3.3 turned ``zarr.codecs.bytes.Endian`` into a deprecation shim — a class with no members
+    and no constructor, whose member access returns the equivalent string. Earlier zarr versions
+    still ship it as a real enum, so ``getattr`` below unwraps a member from either era to its
+    string value.
     """
     if data is None:
         return None
+    data = getattr(data, "value", data)
     if isinstance(data, str) and data in ("little", "big"):
         return cast("EndianLiteral", data)
     raise ValueError(

--- a/src/virtual_tiff/codecs.py
+++ b/src/virtual_tiff/codecs.py
@@ -13,7 +13,7 @@ from zarr.abc.codec import (
     CodecJSON_V2,
     CodecJSON_V3,
 )
-from zarr.codecs.bytes import Endian
+from zarr.codecs.bytes import EndianLiteral
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
 from zarr.core.common import JSON
 from zarr.registry import register_codec
@@ -29,13 +29,18 @@ def check_codecjson_v2(data: object) -> bool:
 ZarrFormat = Literal[2, 3]
 
 
-def _parse_endian(data: object) -> Endian | None:
+def _parse_endian(data: object) -> EndianLiteral | None:
+    """Endianness as zarr 3.3 wants it: the literal string.
+
+    ``zarr.codecs.bytes.Endian`` is a deprecation shim there — a class with no members and no
+    constructor — so ``Endian("little")`` raises ``TypeError: Endian() takes no arguments``.
+    Accessing a member of it returns the equivalent string, so a caller passing ``Endian.little``
+    still lands in the string branch below.
+    """
     if data is None:
         return None
-    if isinstance(data, Endian):
-        return data
     if isinstance(data, str) and data in ("little", "big"):
-        return Endian(data)
+        return cast("EndianLiteral", data)
     raise ValueError(
         f"Invalid endian value: {data!r}. Expected 'little', 'big', or None."
     )
@@ -45,9 +50,9 @@ def _parse_endian(data: object) -> Endian | None:
 class ChunkyCodec(ArrayBytesCodec):
     is_fixed_size = True
 
-    endian: Endian | None
+    endian: EndianLiteral | None
 
-    def __init__(self, *, endian: Endian | str | None = "little") -> None:
+    def __init__(self, *, endian: str | None = "little") -> None:
         object.__setattr__(self, "endian", _parse_endian(endian))
 
     @classmethod
@@ -86,13 +91,13 @@ class ChunkyCodec(ArrayBytesCodec):
     def to_json(self, zarr_format: ZarrFormat) -> CodecJSON_V2 | CodecJSON_V3:
         if zarr_format == 2:
             if self.endian is not None:
-                return {"id": "ChunkyCodec", "endian": self.endian.value}  # type: ignore[return-value, typeddict-item]
+                return {"id": "ChunkyCodec", "endian": self.endian}  # type: ignore[return-value, typeddict-item]
             return {"id": "ChunkyCodec"}  # type: ignore[return-value]
         elif zarr_format == 3:
             if self.endian is not None:
                 return {
                     "name": "ChunkyCodec",
-                    "configuration": {"endian": self.endian.value},
+                    "configuration": {"endian": self.endian},
                 }
             return {"name": "ChunkyCodec"}
         raise ValueError(
@@ -116,7 +121,7 @@ class ChunkyCodec(ArrayBytesCodec):
     ) -> NDBuffer:
         assert isinstance(chunk_bytes, Buffer)
         if chunk_spec.dtype.item_size > 0:
-            if self.endian == Endian.little:
+            if self.endian == "little":
                 prefix = "<"
             else:
                 prefix = ">"
@@ -155,7 +160,7 @@ class ChunkyCodec(ArrayBytesCodec):
         ):
             # type-ignore is a numpy bug
             # see https://github.com/numpy/numpy/issues/26473
-            new_dtype = chunk_array.dtype.newbyteorder(self.endian.name)  # type: ignore[arg-type]
+            new_dtype = chunk_array.dtype.newbyteorder(self.endian)  # type: ignore[arg-type]
             chunk_array = chunk_array.astype(new_dtype)
 
         nd_array = chunk_array.as_ndarray_like()

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -360,8 +360,19 @@ async def _open_tiff(*, path: str, store: ObjectStore) -> TIFF:
 def _construct_manifest_array(
     *, ifd: ImageFileDirectory, url: str, endian: str
 ) -> ManifestArray:
-    if ifd.other_tags.get(330):
-        raise NotImplementedError("TIFFs with Sub-IFDs are not yet supported.")
+    subifds = ifd.other_tags.get(330)
+    if subifds:
+        # Tag 330 lists offsets of reduced-resolution IFDs. They are additional levels, not part of
+        # this IFD: its own tile offsets and byte counts describe it completely, so the array built
+        # below is correct. What is lost is the pyramid, because async_tiff parses IFDs by index in
+        # the top-level chain and offers no way to parse one at a given offset.
+        warnings.warn(
+            f"This IFD carries {len(subifds)} SubIFD(s) (tag 330), which hold reduced-resolution "
+            "levels. Only top-level IFDs can be parsed, so those levels are absent from the "
+            "ManifestStore; this array is the full-resolution image.",
+            UserWarning,
+            stacklevel=2,
+        )
     shape: Tuple[int, ...] = (ifd.image_height, ifd.image_width)
     dtype = _get_dtype(
         sample_format=ifd.sample_format, bits_per_sample=ifd.bits_per_sample

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -467,6 +467,16 @@ def _construct_manifest_group(
         )
 
 
+def _subifd_offsets(ifd: ImageFileDirectory) -> list[int]:
+    """The offsets in tag 330, whether the tag holds one or a list."""
+    value = ifd.other_tags.get(330)
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, int)]
+    return []
+
+
 def _levels_of(
     tiff: TIFF, ifd: ImageFileDirectory, url: str, endian: str, name: str
 ) -> dict[str, ManifestArray]:
@@ -475,10 +485,7 @@ def _levels_of(
     SubIFDs are outside the top-level chain, so they are read at the offsets the tag gives.
     """
     arrays = {name: _construct_manifest_array(ifd=ifd, url=url, endian=endian)}
-    offsets = ifd.other_tags.get(330) or []
-    if isinstance(offsets, int):
-        offsets = [offsets]
-    for level, offset in enumerate(offsets):
+    for level, offset in enumerate(_subifd_offsets(ifd)):
         reduced = sync(_read_ifd_at(tiff, offset))
         arrays[f"{name}.{level}"] = _construct_manifest_array(
             ifd=reduced, url=url, endian=endian
@@ -515,13 +522,12 @@ def _build_manifest_arrays(
         if subifds:
             manifest_arrays.update(_levels_of(tiff, ifd, url, endian, str(idx)))
         else:
-            levels = ifd.other_tags.get(330)
+            levels = _subifd_offsets(ifd)
             if levels:
                 # The IFD's own offsets and byte counts describe it completely, so the array
                 # built below is correct without its SubIFDs.
-                count = 1 if isinstance(levels, int) else len(levels)
                 warnings.warn(
-                    f"This IFD carries {count} SubIFD(s) (tag 330), which hold "
+                    f"This IFD carries {len(levels)} SubIFD(s) (tag 330), which hold "
                     "reduced-resolution levels; this array is the full-resolution image alone. "
                     "Pass `subifds=True` to include them.",
                     UserWarning,

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -358,8 +358,8 @@ async def _open_tiff(*, path: str, store: ObjectStore) -> TIFF:
 
 
 async def _read_ifd_at(tiff: TIFF, offset: int) -> ImageFileDirectory:
-    # Awaited inside the loop rather than called outside it: the binding builds its future against
-    # the running loop, so `sync(tiff.ifd_at(offset))` would construct it before there is one.
+    # `sync(tiff.ifd_at(offset))` would build the binding's future before the loop runs;
+    # awaiting here builds it inside.
     return await tiff.ifd_at(offset)
 
 
@@ -472,9 +472,7 @@ def _levels_of(
 ) -> dict[str, ManifestArray]:
     """An IFD and the reduced levels its tag 330 points at, named `name`, `name.0`, `name.1`, ...
 
-    SubIFDs are not in the top-level chain, so they have to be read at the offsets the tag gives.
-    Writers that produce pyramids this way — microscopy formats commonly do — otherwise appear to
-    hold a single resolution.
+    SubIFDs are outside the top-level chain, so they are read at the offsets the tag gives.
     """
     arrays = {name: _construct_manifest_array(ifd=ifd, url=url, endian=endian)}
     offsets = ifd.other_tags.get(330) or []
@@ -519,9 +517,8 @@ def _build_manifest_arrays(
         else:
             levels = ifd.other_tags.get(330)
             if levels:
-                # Tag 330 lists offsets of reduced-resolution IFDs. They are additional levels,
-                # not part of this IFD: its own tile offsets and byte counts describe it
-                # completely, so the array built below is correct with or without them.
+                # The IFD's own offsets and byte counts describe it completely, so the array
+                # built below is correct without its SubIFDs.
                 count = 1 if isinstance(levels, int) else len(levels)
                 warnings.warn(
                     f"This IFD carries {count} SubIFD(s) (tag 330), which hold "
@@ -582,10 +579,9 @@ class VirtualTIFF:
                 "flat" for all arrays to be contained in a single group. Choose "nested" for each array to be contained in a
                 different group. "nested" is compatible with Xarray's DataTree model, because
                 each node in the DataTree needs to be a Dataset (i.e., group) rather than Dataarray (i.e., array). Default is "flat".
-            subifds : Whether to include the reduced-resolution levels an IFD's tag 330 points at, as
-                arrays named after it -- "0", "0.0", "0.1" and so on. Those IFDs are not in the
-                top-level chain, so they are read at the offsets the tag gives. Default is False,
-                which reports the full-resolution image alone and warns when levels exist.
+            subifds : Whether to include the reduced-resolution levels an IFD's tag 330 points at,
+                as arrays named "0", "0.0", "0.1" and so on. Default is False: the full-resolution
+                image alone, with a warning when levels exist.
         """
         self._ifd = ifd
         self.ifd_layout = ifd_layout

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -364,20 +364,8 @@ async def _read_ifd_at(tiff: TIFF, offset: int) -> ImageFileDirectory:
 
 
 def _construct_manifest_array(
-    *, ifd: ImageFileDirectory, url: str, endian: str, warn_about_subifds: bool = True
+    *, ifd: ImageFileDirectory, url: str, endian: str
 ) -> ManifestArray:
-    subifds = ifd.other_tags.get(330)
-    if subifds and warn_about_subifds:
-        # Tag 330 lists offsets of reduced-resolution IFDs. They are additional levels, not part of
-        # this IFD: its own tile offsets and byte counts describe it completely, so the array built
-        # below is correct with or without them. Pass `subifds=True` to the parser to read them.
-        warnings.warn(
-            f"This IFD carries {len(subifds)} SubIFD(s) (tag 330), which hold reduced-resolution "
-            "levels; this array is the full-resolution image alone. Pass `subifds=True` to include "
-            "them.",
-            UserWarning,
-            stacklevel=2,
-        )
     shape: Tuple[int, ...] = (ifd.image_height, ifd.image_width)
     dtype = _get_dtype(
         sample_format=ifd.sample_format, bits_per_sample=ifd.bits_per_sample
@@ -488,18 +476,14 @@ def _levels_of(
     Writers that produce pyramids this way — microscopy formats commonly do — otherwise appear to
     hold a single resolution.
     """
-    arrays = {
-        name: _construct_manifest_array(
-            ifd=ifd, url=url, endian=endian, warn_about_subifds=False
-        )
-    }
+    arrays = {name: _construct_manifest_array(ifd=ifd, url=url, endian=endian)}
     offsets = ifd.other_tags.get(330) or []
     if isinstance(offsets, int):
         offsets = [offsets]
     for level, offset in enumerate(offsets):
         reduced = sync(_read_ifd_at(tiff, offset))
         arrays[f"{name}.{level}"] = _construct_manifest_array(
-            ifd=reduced, url=url, endian=endian, warn_about_subifds=False
+            ifd=reduced, url=url, endian=endian
         )
     return arrays
 
@@ -533,6 +517,19 @@ def _build_manifest_arrays(
         if subifds:
             manifest_arrays.update(_levels_of(tiff, ifd, url, endian, str(idx)))
         else:
+            levels = ifd.other_tags.get(330)
+            if levels:
+                # Tag 330 lists offsets of reduced-resolution IFDs. They are additional levels,
+                # not part of this IFD: its own tile offsets and byte counts describe it
+                # completely, so the array built below is correct with or without them.
+                count = 1 if isinstance(levels, int) else len(levels)
+                warnings.warn(
+                    f"This IFD carries {count} SubIFD(s) (tag 330), which hold "
+                    "reduced-resolution levels; this array is the full-resolution image alone. "
+                    "Pass `subifds=True` to include them.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             manifest_arrays[str(idx)] = _construct_manifest_array(
                 ifd=ifd, url=url, endian=endian
             )

--- a/src/virtual_tiff/parser.py
+++ b/src/virtual_tiff/parser.py
@@ -357,19 +357,24 @@ async def _open_tiff(*, path: str, store: ObjectStore) -> TIFF:
     return await TIFF.open(path, store=store)
 
 
+async def _read_ifd_at(tiff: TIFF, offset: int) -> ImageFileDirectory:
+    # Awaited inside the loop rather than called outside it: the binding builds its future against
+    # the running loop, so `sync(tiff.ifd_at(offset))` would construct it before there is one.
+    return await tiff.ifd_at(offset)
+
+
 def _construct_manifest_array(
-    *, ifd: ImageFileDirectory, url: str, endian: str
+    *, ifd: ImageFileDirectory, url: str, endian: str, warn_about_subifds: bool = True
 ) -> ManifestArray:
     subifds = ifd.other_tags.get(330)
-    if subifds:
+    if subifds and warn_about_subifds:
         # Tag 330 lists offsets of reduced-resolution IFDs. They are additional levels, not part of
         # this IFD: its own tile offsets and byte counts describe it completely, so the array built
-        # below is correct. What is lost is the pyramid, because async_tiff parses IFDs by index in
-        # the top-level chain and offers no way to parse one at a given offset.
+        # below is correct with or without them. Pass `subifds=True` to the parser to read them.
         warnings.warn(
             f"This IFD carries {len(subifds)} SubIFD(s) (tag 330), which hold reduced-resolution "
-            "levels. Only top-level IFDs can be parsed, so those levels are absent from the "
-            "ManifestStore; this array is the full-resolution image.",
+            "levels; this array is the full-resolution image alone. Pass `subifds=True` to include "
+            "them.",
             UserWarning,
             stacklevel=2,
         )
@@ -441,6 +446,7 @@ def _construct_manifest_group(
     *,
     ifd: int | None = None,
     ifd_layout: Literal["flat", "nested"] = "flat",
+    subifds: bool = False,
 ) -> ManifestGroup:
     """Construct a ManifestGroup from TIFF IFDs.
 
@@ -449,6 +455,7 @@ def _construct_manifest_group(
         path: Full URL path to the TIFF file
         ifd: Specific IFD index to process, or None for all IFDs
         ifd_layout: How to organize IFDs - 'flat' for single group, 'nested' for group per IFD
+        subifds: Whether to include the reduced levels an IFD's tag 330 points at
 
     Returns:
         ManifestGroup containing the processed TIFF data
@@ -458,7 +465,7 @@ def _construct_manifest_group(
     endian = _ENDIANNESS_TO_STR[tiff.endianness]
 
     # Build manifest arrays from selected IFDs
-    manifest_arrays = _build_manifest_arrays(tiff, url, endian, ifd)
+    manifest_arrays = _build_manifest_arrays(tiff, url, endian, ifd, subifds)
 
     # Organize into appropriate group structure
     attrs: dict[str, Any] = {}
@@ -472,11 +479,37 @@ def _construct_manifest_group(
         )
 
 
+def _levels_of(
+    tiff: TIFF, ifd: ImageFileDirectory, url: str, endian: str, name: str
+) -> dict[str, ManifestArray]:
+    """An IFD and the reduced levels its tag 330 points at, named `name`, `name.0`, `name.1`, ...
+
+    SubIFDs are not in the top-level chain, so they have to be read at the offsets the tag gives.
+    Writers that produce pyramids this way — microscopy formats commonly do — otherwise appear to
+    hold a single resolution.
+    """
+    arrays = {
+        name: _construct_manifest_array(
+            ifd=ifd, url=url, endian=endian, warn_about_subifds=False
+        )
+    }
+    offsets = ifd.other_tags.get(330) or []
+    if isinstance(offsets, int):
+        offsets = [offsets]
+    for level, offset in enumerate(offsets):
+        reduced = sync(_read_ifd_at(tiff, offset))
+        arrays[f"{name}.{level}"] = _construct_manifest_array(
+            ifd=reduced, url=url, endian=endian, warn_about_subifds=False
+        )
+    return arrays
+
+
 def _build_manifest_arrays(
     tiff: TIFF,
     url: str,
     endian: str,
     ifd_index: int | None,
+    subifds: bool = False,
 ) -> dict[str, ManifestArray]:
     """Build manifest arrays from TIFF IFDs.
 
@@ -491,14 +524,15 @@ def _build_manifest_arrays(
     """
     manifest_arrays = {}
 
-    if ifd_index is not None:
-        # Process single specified IFD
-        manifest_arrays[str(ifd_index)] = _construct_manifest_array(
-            ifd=tiff.ifds[ifd_index], url=url, endian=endian
-        )
-    else:
-        # Process all IFDs
-        for idx, ifd in enumerate(tiff.ifds):
+    chosen = (
+        [(ifd_index, tiff.ifds[ifd_index])]
+        if ifd_index is not None
+        else list(enumerate(tiff.ifds))
+    )
+    for idx, ifd in chosen:
+        if subifds:
+            manifest_arrays.update(_levels_of(tiff, ifd, url, endian, str(idx)))
+        else:
             manifest_arrays[str(idx)] = _construct_manifest_array(
                 ifd=ifd, url=url, endian=endian
             )
@@ -538,7 +572,10 @@ def _create_nested_group(
 
 class VirtualTIFF:
     def __init__(
-        self, ifd: int | None = None, ifd_layout: Literal["flat", "nested"] = "flat"
+        self,
+        ifd: int | None = None,
+        ifd_layout: Literal["flat", "nested"] = "flat",
+        subifds: bool = False,
     ) -> None:
         """Configure VirtualTIFF parser.
 
@@ -548,9 +585,14 @@ class VirtualTIFF:
                 "flat" for all arrays to be contained in a single group. Choose "nested" for each array to be contained in a
                 different group. "nested" is compatible with Xarray's DataTree model, because
                 each node in the DataTree needs to be a Dataset (i.e., group) rather than Dataarray (i.e., array). Default is "flat".
+            subifds : Whether to include the reduced-resolution levels an IFD's tag 330 points at, as
+                arrays named after it -- "0", "0.0", "0.1" and so on. Those IFDs are not in the
+                top-level chain, so they are read at the offsets the tag gives. Default is False,
+                which reports the full-resolution image alone and warns when levels exist.
         """
         self._ifd = ifd
         self.ifd_layout = ifd_layout
+        self.subifds = subifds
 
     def __call__(self, url: str, registry: ObjectStoreRegistry) -> ManifestStore:
         """Produce a ManifestStore from a file path and object store instance.
@@ -570,6 +612,7 @@ class VirtualTIFF:
             path=path_in_store,
             ifd=self._ifd,
             ifd_layout=self.ifd_layout,
+            subifds=self.subifds,
         )
         # Convert to a manifest store
         return ManifestStore(registry=registry, group=manifest_group)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -102,16 +102,23 @@ def test_parse_endian_none():
     assert _parse_endian(None) is None
 
 
+def _endian_member(name):
+    """``Endian.<name>`` without the deprecation warning zarr 3.3 attaches to member access."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return getattr(Endian, name)
+
+
 def test_parse_endian_string_little():
-    assert _parse_endian("little") == Endian.little
+    assert _parse_endian("little") == "little"
 
 
 def test_parse_endian_string_big():
-    assert _parse_endian("big") == Endian.big
+    assert _parse_endian("big") == "big"
 
 
-def test_parse_endian_enum_passthrough():
-    assert _parse_endian(Endian.big) is Endian.big
+def test_parse_endian_unwraps_an_endian_member():
+    assert _parse_endian(_endian_member("big")) == "big"
 
 
 def test_parse_endian_invalid():
@@ -129,7 +136,7 @@ def test_parse_endian_invalid_type():
 
 def test_chunky_codec_default_endian():
     codec = ChunkyCodec()
-    assert codec.endian == Endian.little
+    assert codec.endian == "little"
 
 
 @pytest.mark.parametrize("endian", ["big", "little"])
@@ -144,11 +151,11 @@ def test_chunky_codec_endian_is_a_literal_string(endian):
     assert codec.to_json(zarr_format=3)["configuration"]["endian"] == endian
 
 
-def test_chunky_codec_accepts_a_deprecated_endian_member():
-    """Accessing a member of the shim returns the equivalent string, so old callers keep working."""
-    with pytest.warns(DeprecationWarning):
-        member = Endian.big
-    assert ChunkyCodec(endian=member).endian == "big"
+def test_chunky_codec_accepts_an_endian_member():
+    """A caller holding `Endian.big` lands on the string, whether their zarr ships it as a real
+    enum member (before 3.3) or as the shim whose member access returns the string (3.3 on).
+    """
+    assert ChunkyCodec(endian=_endian_member("big")).endian == "big"
 
 
 @pytest.mark.parametrize("endian", ["big", "little"])
@@ -206,7 +213,7 @@ def test_chunky_codec_none_endian_to_json_v2():
 def test_chunky_codec_from_json_v3_string_only():
     """A v3 codec can be just a name string with no configuration."""
     restored = ChunkyCodec._from_json_v3("virtual_tiff.ChunkyCodec")
-    assert restored.endian == Endian.little  # default
+    assert restored.endian == "little"  # default
 
 
 def test_chunky_codec_from_json_v2_invalid():
@@ -259,14 +266,14 @@ def test_chunky_codec_evolve_from_array_spec_single_byte():
     """endian should be preserved for single-byte dtypes (item_size > 0)."""
     codec = ChunkyCodec(endian="little")
     evolved = codec.evolve_from_array_spec(_make_spec((10,), UInt8()))
-    assert evolved.endian == Endian.little
+    assert evolved.endian == "little"
 
 
 def test_chunky_codec_evolve_from_array_spec_multi_byte():
     """endian should be preserved for multi-byte dtypes."""
     codec = ChunkyCodec(endian="big")
     evolved = codec.evolve_from_array_spec(_make_spec((10,), UInt16()))
-    assert evolved.endian == Endian.big
+    assert evolved.endian == "big"
 
 
 def test_chunky_codec_evolve_from_array_spec_none_endian_multi_byte():

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -141,9 +141,8 @@ def test_chunky_codec_default_endian():
 
 @pytest.mark.parametrize("endian", ["big", "little"])
 def test_chunky_codec_endian_is_a_literal_string(endian):
-    """zarr 3.3 turned `Endian` into a deprecation shim: a class with no members and no
-    constructor, so `Endian("little")` raises `TypeError: Endian() takes no arguments`. The codec
-    stores the literal instead, which is what `BytesCodec` does there too.
+    """zarr 3.3's `Endian` shim has no constructor, so the codec stores the literal string,
+    as `BytesCodec` does there too.
     """
     codec = ChunkyCodec(endian=endian)
     assert codec.endian == endian
@@ -152,8 +151,8 @@ def test_chunky_codec_endian_is_a_literal_string(endian):
 
 
 def test_chunky_codec_accepts_an_endian_member():
-    """A caller holding `Endian.big` lands on the string, whether their zarr ships it as a real
-    enum member (before 3.3) or as the shim whose member access returns the string (3.3 on).
+    """`Endian.big` lands on the string, whether zarr ships a real enum (before 3.3) or the
+    shim (3.3 on).
     """
     assert ChunkyCodec(endian=_endian_member("big")).endian == "big"
 
@@ -604,11 +603,9 @@ class TestHorizontalDeltaFloat:
     "codec", ["virtual_tiff.ChunkyCodec", "virtual_tiff.HorizontalDeltaCodec"]
 )
 def test_codec_resolves_without_importing_this_package(codec):
-    """Whoever reads an array written with these codecs need not know about virtual-tiff.
+    """The `zarr.codecs` entry point resolves the codec without this package being imported.
 
-    The name in the array's metadata is what the `zarr.codecs` entry point publishes, so zarr
-    finds the class on its own. A subprocess is what makes the test meaningful: importing this
-    module has already registered both codecs by hand.
+    A subprocess is the point: importing this module already registered both codecs by hand.
     """
     import subprocess
     import sys

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -133,6 +133,25 @@ def test_chunky_codec_default_endian():
 
 
 @pytest.mark.parametrize("endian", ["big", "little"])
+def test_chunky_codec_endian_is_a_literal_string(endian):
+    """zarr 3.3 turned `Endian` into a deprecation shim: a class with no members and no
+    constructor, so `Endian("little")` raises `TypeError: Endian() takes no arguments`. The codec
+    stores the literal instead, which is what `BytesCodec` does there too.
+    """
+    codec = ChunkyCodec(endian=endian)
+    assert codec.endian == endian
+    assert isinstance(codec.endian, str)
+    assert codec.to_json(zarr_format=3)["configuration"]["endian"] == endian
+
+
+def test_chunky_codec_accepts_a_deprecated_endian_member():
+    """Accessing a member of the shim returns the equivalent string, so old callers keep working."""
+    with pytest.warns(DeprecationWarning):
+        member = Endian.big
+    assert ChunkyCodec(endian=member).endian == "big"
+
+
+@pytest.mark.parametrize("endian", ["big", "little"])
 def test_chunky_codec_roundtrip_preserves_endian(endian):
     """ChunkyCodec.to_dict must include the endian config so that
     big-endian data is not silently reinterpreted as little-endian

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -141,7 +141,7 @@ def test_chunky_codec_default_endian():
 
 @pytest.mark.parametrize("endian", ["big", "little"])
 def test_chunky_codec_endian_is_a_literal_string(endian):
-    """zarr 3.3's `Endian` shim has no constructor, so the codec stores the literal string,
+    """zarr 3.3's `Endian` adapter has no constructor, so the codec stores the literal string,
     as `BytesCodec` does there too.
     """
     codec = ChunkyCodec(endian=endian)
@@ -152,7 +152,7 @@ def test_chunky_codec_endian_is_a_literal_string(endian):
 
 def test_chunky_codec_accepts_an_endian_member():
     """`Endian.big` lands on the string, whether zarr ships a real enum (before 3.3) or the
-    shim (3.3 on).
+    adapter (3.3 on).
     """
     assert ChunkyCodec(endian=_endian_member("big")).endian == "big"
 
@@ -605,7 +605,7 @@ class TestHorizontalDeltaFloat:
 def test_codec_resolves_without_importing_this_package(codec):
     """The `zarr.codecs` entry point resolves the codec without this package being imported.
 
-    A subprocess is the point: importing this module already registered both codecs by hand.
+    Need to run in a subprocess because importing this module already registered both codecs.
     """
     import subprocess
     import sys

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -165,7 +165,7 @@ def test_chunky_codec_roundtrip_preserves_endian(endian):
 def test_chunky_codec_to_json_v3(endian):
     codec = ChunkyCodec(endian=endian)
     v3 = codec.to_json(zarr_format=3)
-    assert v3["name"] == "ChunkyCodec"
+    assert v3["name"] == "virtual_tiff.ChunkyCodec"
     assert v3["configuration"]["endian"] == endian
     restored = ChunkyCodec.from_json(v3)
     assert restored.endian == codec.endian
@@ -192,7 +192,7 @@ def test_chunky_codec_from_json_auto_detects_format():
 def test_chunky_codec_none_endian_to_json_v3():
     codec = ChunkyCodec(endian=None)
     v3 = codec.to_json(zarr_format=3)
-    assert v3 == {"name": "ChunkyCodec"}
+    assert v3 == {"name": "virtual_tiff.ChunkyCodec"}
     assert "configuration" not in v3
 
 
@@ -205,7 +205,7 @@ def test_chunky_codec_none_endian_to_json_v2():
 
 def test_chunky_codec_from_json_v3_string_only():
     """A v3 codec can be just a name string with no configuration."""
-    restored = ChunkyCodec._from_json_v3("ChunkyCodec")
+    restored = ChunkyCodec._from_json_v3("virtual_tiff.ChunkyCodec")
     assert restored.endian == Endian.little  # default
 
 
@@ -282,7 +282,7 @@ def test_chunky_codec_evolve_from_array_spec_none_endian_multi_byte():
 def test_horizontal_delta_to_json_v3():
     codec = HorizontalDeltaCodec()
     v3 = codec.to_json(zarr_format=3)
-    assert v3 == {"name": "HorizontalDeltaCodec"}
+    assert v3 == {"name": "virtual_tiff.HorizontalDeltaCodec"}
     restored = HorizontalDeltaCodec.from_json(v3)
     assert isinstance(restored, HorizontalDeltaCodec)
 
@@ -591,3 +591,28 @@ class TestHorizontalDeltaFloat:
         spec = _make_spec((1, 3), UInt16())
         result = await codec._decode_single(nd_buf, spec)
         np.testing.assert_array_equal(result.as_ndarray_like(), original)
+
+
+@pytest.mark.parametrize(
+    "codec", ["virtual_tiff.ChunkyCodec", "virtual_tiff.HorizontalDeltaCodec"]
+)
+def test_codec_resolves_without_importing_this_package(codec):
+    """Whoever reads an array written with these codecs need not know about virtual-tiff.
+
+    The name in the array's metadata is what the `zarr.codecs` entry point publishes, so zarr
+    finds the class on its own. A subprocess is what makes the test meaningful: importing this
+    module has already registered both codecs by hand.
+    """
+    import subprocess
+    import sys
+
+    source = (
+        "import zarr.registry, sys;"
+        f"cls = zarr.registry.get_codec_class({codec!r});"
+        "assert 'virtual_tiff.codecs' in sys.modules, 'entry point did not load the module';"
+        "print(cls.__name__)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", source], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_ome_tiff_microscopy.py
+++ b/tests/test_ome_tiff_microscopy.py
@@ -1,22 +1,18 @@
-"""OME-TIFFs as microscopy platforms write them, which this parser does not read yet.
+"""OME-TIFFs as microscopy platforms write them.
 
-Three published files, three distinct blockers. Each is a real object on a public host — the same
-files a spatial-omics reader is handed — and each test asserts the *current* failure so that fixing
-one turns its test red rather than leaving it silently passing.
+Three published files that this parser could not read, each for a different reason and none of them
+about codecs — the JPEG 2000 tags they use were already in `COMPRESSORS`, and both planar
+configurations were already handled. What stopped them:
 
-* `IfdBig` — 10x's Xenium morphology images are BigTIFFs whose tags use the 64-bit IFD8 value type.
-  `async_tiff` raises `RuntimeError: Unsupported value type 'IfdBig'` before any codec is consulted,
-  so the JPEG 2000 support this parser already has is unreachable for them.
-* Sub-IFDs — their H&E images carry the pyramid in SubIFDs rather than as top-level IFDs. The
-  parser used to decline outright; it now maps the requested IFD and warns that the levels behind
-  tag 330 are absent, because `async_tiff` parses IFDs by index in the top-level chain and offers no
-  way to parse one at a given offset.
-* Large objects over HTTP — a 17.7 GB uncompressed OME-TIFF fails while `async_tiff` reads the
-  directory, with `Generic HTTP error: request or response body error`, reproducibly. Ranged GETs
-  against the same object with a plain HTTP client succeed, so this is not the server refusing.
+* a BigTIFF whose tags use the 64-bit IFD8 value type, which `async_tiff`'s Python layer refused
+  while reading the directory, so one tag made the file unopenable;
+* a pyramid written into SubIFDs rather than the top-level IFD chain, which this parser declined
+  outright and could not have reached anyway;
+* a 17.7 GB image whose first IFD sits in its last kilobytes, which made a metadata cache that fills
+  from offset 0 request the whole object.
 
-The files are 1.2 GB, 3.7 GB and 17.7 GB, and nothing here downloads them: a parser reads only the
-directory.
+All three read now. The files are 1.2 GB, 4.8 GB and 17.7 GB, and nothing here downloads them: a
+parser reads only the directory.
 """
 
 from __future__ import annotations
@@ -42,40 +38,66 @@ def parse(host: str, url: str, **kwargs):
 
 
 @requires_network
-def test_bigtiff_with_ifd8_tag_values_is_refused():
-    """Xenium morphology: a BigTIFF whose tag values use the IFD8 type.
+def test_bigtiff_with_ifd8_tag_values_reads():
+    """Xenium morphology: a BigTIFF whose tag 330 is typed IFD8, with JPEG 2000 tiles.
 
-    JPEG 2000 tiles (compression 33003/33005) are already in `COMPRESSORS`, so this file would be
-    readable if the directory could be parsed at all.
+    Eleven top-level IFDs, which here are focal planes rather than levels — the levels are the
+    SubIFDs each of them carries.
     """
-    with pytest.raises(RuntimeError, match="Unsupported value type 'IfdBig'"):
-        parse(TENX, XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_morphology.ome.tif", ifd=0)
+    store = parse(TENX, XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_morphology.ome.tif")
+    arrays = store._group.arrays
+    assert len(arrays) == 11
+    first = arrays["0"]
+    assert tuple(first.shape) == (17098, 51187)
+    assert "Jpeg2KCodec" in [type(codec).__name__ for codec in first.metadata.codecs]
 
 
 @requires_network
-def test_pyramid_in_subifds_warns_and_still_maps_the_full_resolution_level():
-    """Xenium H&E: interleaved RGB, 45087 x 11580, whose five reduced levels are SubIFDs.
+def test_subifd_levels_are_read_when_asked_for():
+    """Xenium H&E: five reduced levels, each half the last, outside the top-level chain.
 
-    Tag 330 lists offsets of *other* IFDs, so this IFD's own tile offsets describe it completely and
-    the array is correct — the pyramid is what goes missing. The pixels are checked against
-    tifffile's own read of the same window, so "it parsed" is not mistaken for "it is right".
+    Without `subifds=True` the same file reports the full-resolution image alone, and says so.
     """
+    url = XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif"
+    arrays = parse(TENX, url, ifd=0, subifds=True)._group.arrays
+    assert list(arrays) == ["0", "0.0", "0.1", "0.2", "0.3", "0.4"]
+    assert [tuple(a.shape) for a in arrays.values()] == [
+        (3, 45087, 11580),
+        (3, 22544, 5790),
+        (3, 11272, 2895),
+        (3, 5636, 1448),
+        (3, 2818, 724),
+        (3, 1409, 362),
+    ]
+    assert sum(len(list(a.manifest.values())) for a in arrays.values()) == 731
+
+    with pytest.warns(UserWarning, match="SubIFD"):
+        alone = parse(TENX, url, ifd=0)._group.arrays
+    assert list(alone) == ["0"]
+
+
+@requires_network
+def test_the_directory_of_a_17gb_object_is_reachable():
+    """Atera H&E: uncompressed, tiled, planar, ten levels, first IFD at byte 17,731,963,126.
+
+    Its metadata is in the last kilobytes of the file, which is where a cache that fills from the
+    front has to stop being sequential.
+    """
+    array = parse(AWS, ATERA + "he_image.ome.tif", ifd=0)._group.arrays["0"]
+    assert tuple(array.shape) == (3, 47337, 90368)
+    assert len(list(array.manifest.values())) == 12_549
+
+
+@requires_network
+def test_the_pixels_are_the_files_own():
+    """That it parses is not that it is right: compare a window against tifffile's own read."""
     tifffile = pytest.importorskip("tifffile")
     fsspec = pytest.importorskip("fsspec")
     import numpy as np
     import zarr
 
     url = XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif"
-    with pytest.warns(UserWarning, match="SubIFD"):
-        store = parse(TENX, url, ifd=0)
-
-    array = zarr.open_array(store, path="0", mode="r")
-    assert array.shape == (3, 45087, 11580)
-    assert [type(codec).__name__ for codec in array.metadata.codecs] == [
-        "TransposeCodec",
-        "ChunkyCodec",
-        "Zlib",
-    ]
+    array = zarr.open_array(parse(TENX, url, ifd=0, subifds=True), path="0", mode="r")
 
     rows, cols = slice(20000, 20064), slice(4000, 4064)
     with fsspec.filesystem("http", block_size=1 << 22).open(url, "rb") as handle:
@@ -83,14 +105,3 @@ def test_pyramid_in_subifds_warns_and_still_maps_the_full_resolution_level():
         # tifffile hands back (y, x, samples) for a chunky page; the manifest is (c, y, x).
         expected = np.moveaxis(page.asarray()[rows, cols], -1, 0)
     assert np.array_equal(np.asarray(array[:, rows, cols]), expected)
-
-
-@requires_network
-def test_reading_the_directory_of_a_17gb_object_over_http_fails():
-    """Atera H&E: uncompressed, tiled, planar, ten levels, 17.7 GB.
-
-    Every level is `planar_configuration` 2 with 1 MiB tiles, which this parser supports, and a
-    plain HTTP client fetches any of those tiles by range. It is reading the *directory* that fails.
-    """
-    with pytest.raises(Exception, match="body error"):
-        parse(AWS, ATERA + "he_image.ome.tif", ifd=0)

--- a/tests/test_ome_tiff_microscopy.py
+++ b/tests/test_ome_tiff_microscopy.py
@@ -1,18 +1,13 @@
 """OME-TIFFs as microscopy platforms write them.
 
-Three published files that this parser could not read, each for a different reason and none of them
-about codecs — the JPEG 2000 tags they use were already in `COMPRESSORS`, and both planar
-configurations were already handled. What stopped them:
+Three published files this parser could not read:
 
-* a BigTIFF whose tags use the 64-bit IFD8 value type, which `async_tiff`'s Python layer refused
-  while reading the directory, so one tag made the file unopenable;
-* a pyramid written into SubIFDs rather than the top-level IFD chain, which this parser declined
-  outright and could not have reached anyway;
-* a 17.7 GB image whose first IFD sits in its last kilobytes, which made a metadata cache that fills
-  from offset 0 request the whole object.
+* a BigTIFF whose tags use the 64-bit IFD8 value type, which `async_tiff` refused;
+* a pyramid written into SubIFDs rather than the top-level IFD chain;
+* a 17.7 GB image whose first IFD sits in its last kilobytes, which a metadata cache filling
+  from offset 0 turned into a whole-object request.
 
-All three read now. The files are 1.2 GB, 4.8 GB and 17.7 GB, and nothing here downloads them: a
-parser reads only the directory.
+Nothing here downloads the images (1.2 to 17.7 GB): a parser reads only the directory.
 """
 
 from __future__ import annotations
@@ -41,8 +36,7 @@ def parse(host: str, url: str, **kwargs):
 def test_bigtiff_with_ifd8_tag_values_reads():
     """Xenium morphology: a BigTIFF whose tag 330 is typed IFD8, with JPEG 2000 tiles.
 
-    Eleven top-level IFDs, which here are focal planes rather than levels — the levels are the
-    SubIFDs each of them carries.
+    The eleven top-level IFDs are focal planes; the levels are their SubIFDs.
     """
     store = parse(TENX, XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_morphology.ome.tif")
     arrays = store._group.arrays
@@ -54,10 +48,7 @@ def test_bigtiff_with_ifd8_tag_values_reads():
 
 @requires_network
 def test_subifd_levels_are_read_when_asked_for():
-    """Xenium H&E: five reduced levels, each half the last, outside the top-level chain.
-
-    Without `subifds=True` the same file reports the full-resolution image alone, and says so.
-    """
+    """Xenium H&E: five reduced levels, each half the last, outside the top-level chain."""
     url = XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif"
     arrays = parse(TENX, url, ifd=0, subifds=True)._group.arrays
     assert list(arrays) == ["0", "0.0", "0.1", "0.2", "0.3", "0.4"]
@@ -78,11 +69,7 @@ def test_subifd_levels_are_read_when_asked_for():
 
 @requires_network
 def test_the_directory_of_a_17gb_object_is_reachable():
-    """Atera H&E: uncompressed, tiled, planar, ten levels, first IFD at byte 17,731,963,126.
-
-    Its metadata is in the last kilobytes of the file, which is where a cache that fills from the
-    front has to stop being sequential.
-    """
+    """Atera H&E: uncompressed, tiled, planar, ten levels, first IFD at byte 17,731,963,126."""
     array = parse(AWS, ATERA + "he_image.ome.tif", ifd=0)._group.arrays["0"]
     assert tuple(array.shape) == (3, 47337, 90368)
     assert len(list(array.manifest.values())) == 12_549

--- a/tests/test_ome_tiff_microscopy.py
+++ b/tests/test_ome_tiff_microscopy.py
@@ -1,0 +1,73 @@
+"""OME-TIFFs as microscopy platforms write them, which this parser does not read yet.
+
+Three published files, three distinct blockers. Each is a real object on a public host — the same
+files a spatial-omics reader is handed — and each test asserts the *current* failure so that fixing
+one turns its test red rather than leaving it silently passing.
+
+* `IfdBig` — 10x's Xenium morphology images are BigTIFFs whose tags use the 64-bit IFD8 value type.
+  `async_tiff` raises `RuntimeError: Unsupported value type 'IfdBig'` before any codec is consulted,
+  so the JPEG 2000 support this parser already has is unreachable for them.
+* Sub-IFDs — their H&E images carry the pyramid in SubIFDs rather than as top-level IFDs, and the
+  parser declines with `NotImplementedError`. `ifd_layout="nested"` does not help: the levels are not
+  IFDs of the file.
+* Large objects over HTTP — a 17.7 GB uncompressed OME-TIFF fails while `async_tiff` reads the
+  directory, with `Generic HTTP error: request or response body error`, reproducibly. Ranged GETs
+  against the same object with a plain HTTP client succeed, so this is not the server refusing.
+
+The files are 1.2 GB, 3.7 GB and 17.7 GB, and nothing here downloads them: a parser reads only the
+directory.
+"""
+
+from __future__ import annotations
+
+import pytest
+from obspec_utils.registry import ObjectStoreRegistry
+from obstore.store import HTTPStore
+
+from virtual_tiff import VirtualTIFF
+
+from .conftest import requires_network
+
+TENX = "https://cf.10xgenomics.com/"
+XENIUM_LUNG = TENX + "samples/xenium/2.0.0/Xenium_V1_humanLung_Cancer_FFPE/"
+AWS = "https://s3-us-west-2.amazonaws.com/"
+ATERA = (AWS + "10x.files/samples/atera/dev/WTA_Preview_FFPE_Cervical_Cancer/"
+         "WTA_Preview_FFPE_Cervical_Cancer_")
+
+
+def parse(host: str, url: str, **kwargs):
+    registry = ObjectStoreRegistry({host: HTTPStore(host)})
+    return VirtualTIFF(**kwargs)(url, registry)
+
+
+@requires_network
+def test_bigtiff_with_ifd8_tag_values_is_refused():
+    """Xenium morphology: a BigTIFF whose tag values use the IFD8 type.
+
+    JPEG 2000 tiles (compression 33003/33005) are already in `COMPRESSORS`, so this file would be
+    readable if the directory could be parsed at all.
+    """
+    with pytest.raises(RuntimeError, match="Unsupported value type 'IfdBig'"):
+        parse(TENX, XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_morphology.ome.tif", ifd=0)
+
+
+@requires_network
+def test_pyramid_in_subifds_is_refused():
+    """Xenium H&E: interleaved RGB whose resolution levels are SubIFDs.
+
+    The parser handles `planar_configuration` 1 through `ChunkyCodec`, so only the pyramid's
+    placement is in the way.
+    """
+    with pytest.raises(NotImplementedError, match="Sub-IFDs"):
+        parse(TENX, XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif", ifd=0)
+
+
+@requires_network
+def test_reading_the_directory_of_a_17gb_object_over_http_fails():
+    """Atera H&E: uncompressed, tiled, planar, ten levels, 17.7 GB.
+
+    Every level is `planar_configuration` 2 with 1 MiB tiles, which this parser supports, and a
+    plain HTTP client fetches any of those tiles by range. It is reading the *directory* that fails.
+    """
+    with pytest.raises(Exception, match="body error"):
+        parse(AWS, ATERA + "he_image.ome.tif", ifd=0)

--- a/tests/test_ome_tiff_microscopy.py
+++ b/tests/test_ome_tiff_microscopy.py
@@ -7,9 +7,10 @@ one turns its test red rather than leaving it silently passing.
 * `IfdBig` — 10x's Xenium morphology images are BigTIFFs whose tags use the 64-bit IFD8 value type.
   `async_tiff` raises `RuntimeError: Unsupported value type 'IfdBig'` before any codec is consulted,
   so the JPEG 2000 support this parser already has is unreachable for them.
-* Sub-IFDs — their H&E images carry the pyramid in SubIFDs rather than as top-level IFDs, and the
-  parser declines with `NotImplementedError`. `ifd_layout="nested"` does not help: the levels are not
-  IFDs of the file.
+* Sub-IFDs — their H&E images carry the pyramid in SubIFDs rather than as top-level IFDs. The
+  parser used to decline outright; it now maps the requested IFD and warns that the levels behind
+  tag 330 are absent, because `async_tiff` parses IFDs by index in the top-level chain and offers no
+  way to parse one at a given offset.
 * Large objects over HTTP — a 17.7 GB uncompressed OME-TIFF fails while `async_tiff` reads the
   directory, with `Generic HTTP error: request or response body error`, reproducibly. Ranged GETs
   against the same object with a plain HTTP client succeed, so this is not the server refusing.
@@ -52,14 +53,36 @@ def test_bigtiff_with_ifd8_tag_values_is_refused():
 
 
 @requires_network
-def test_pyramid_in_subifds_is_refused():
-    """Xenium H&E: interleaved RGB whose resolution levels are SubIFDs.
+def test_pyramid_in_subifds_warns_and_still_maps_the_full_resolution_level():
+    """Xenium H&E: interleaved RGB, 45087 x 11580, whose five reduced levels are SubIFDs.
 
-    The parser handles `planar_configuration` 1 through `ChunkyCodec`, so only the pyramid's
-    placement is in the way.
+    Tag 330 lists offsets of *other* IFDs, so this IFD's own tile offsets describe it completely and
+    the array is correct — the pyramid is what goes missing. The pixels are checked against
+    tifffile's own read of the same window, so "it parsed" is not mistaken for "it is right".
     """
-    with pytest.raises(NotImplementedError, match="Sub-IFDs"):
-        parse(TENX, XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif", ifd=0)
+    tifffile = pytest.importorskip("tifffile")
+    fsspec = pytest.importorskip("fsspec")
+    import numpy as np
+    import zarr
+
+    url = XENIUM_LUNG + "Xenium_V1_humanLung_Cancer_FFPE_he_image.ome.tif"
+    with pytest.warns(UserWarning, match="SubIFD"):
+        store = parse(TENX, url, ifd=0)
+
+    array = zarr.open_array(store, path="0", mode="r")
+    assert array.shape == (3, 45087, 11580)
+    assert [type(codec).__name__ for codec in array.metadata.codecs] == [
+        "TransposeCodec",
+        "ChunkyCodec",
+        "Zlib",
+    ]
+
+    rows, cols = slice(20000, 20064), slice(4000, 4064)
+    with fsspec.filesystem("http", block_size=1 << 22).open(url, "rb") as handle:
+        page = tifffile.TiffFile(handle).series[0].levels[0]
+        # tifffile hands back (y, x, samples) for a chunky page; the manifest is (c, y, x).
+        expected = np.moveaxis(page.asarray()[rows, cols], -1, 0)
+    assert np.array_equal(np.asarray(array[:, rows, cols]), expected)
 
 
 @requires_network


### PR DESCRIPTION
Use three public OME-TIFF examples generated from 10x Genomics in-situ platforms ([Xenium](https://www.10xgenomics.com/platforms/xenium) and [Atera](https://www.10xgenomics.com/platforms/atera)):

- [10x Xenium human lung cancer - morphology][0]: a BigTIFF whose tag 330 is typed IFD8, with JPEG 2000 tiles, which async-tiff refused.
- [10x Xenium human lung cancer - Hematoxylin & Eosin (H&E) staining][0]: a pyramid with five reduced levels, each half the last, outside the top-level chain. Same sample as above.
- [10x Atera human cervical cancer - H&E][1]: a 17.7 GB image whose first IFD sits in its last kilobytes, which a metadata cache filling from offset 0 turned into a whole-object request. uncompressed, tiled, planar, ten levels, first IFD at byte 17,731,963,126.

[0]: https://www.10xgenomics.com/datasets/preview-data-ffpe-human-lung-cancer-with-xenium-multimodal-cell-segmentation-1-standard
[1]: https://www.10xgenomics.com/datasets/atera-wta-ffpe-human-cervical-cancer

The main change needed to support them is SubIFD (tag 330) support. `main` raised `NotImplementedError` on any IFD with tag 330. Now VirtualTIFF takes a `subifds` parameter - when true, the pyramid levels each IFD points at are read at their offsets and exposed as arrays named `"0", "0.0", "0.1", …`; when false (default), only the full-resolution image is built, with a warning that reduced levels exist. Tag 330 values are normalized (single int or list) in one helper. 

Depends on PR https://github.com/developmentseed/async-tiff/pull/328 in `async-tiff` to be merged, to expose the SubIFDs to Python.

---

## Extra compatibility fixes

1. Codec registration under entry-point names: `ChunkyCodec` and `HorizontalDeltaCodec` now register and serialize as `virtual_tiff.ChunkyCodec` / `virtual_tiff.HorizontalDeltaCodec`, matching what the package's `zarr.codecs` entry points publish, so readers that never import the package still resolve them.

2. zarr 3.3 compatibility: `ChunkyCodec.endian` is held as a plain string ("little"/"big") instead of the `Endian` enum. Another [similar branch](https://github.com/virtual-zarr/virtual-tiff/compare/main...fix/chunky-codec-endian-zarr-33) exists in the repo addressing the same issue.